### PR TITLE
Fix FDCT to be 16-bit and ANSI compliant.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,10 @@
 2014-07-03  Jeremy Bennett  <jeremy.bennett@embecosm.com>
 
+	* src/fdct/fdct.c: Include name changed.
+	(int main): Correct initialization function name.
+
+2014-07-03  Jeremy Bennett  <jeremy.bennett@embecosm.com>
+
 	* src/fdct/fdct.c: Use ANSI style comments and 80 column
 	throughout.  Correct expected value for block[12].  Add GPL header.
 	(void fdct): Use long int instead of int for all temporaries.

--- a/src/fdct/fdct.c
+++ b/src/fdct/fdct.c
@@ -58,7 +58,7 @@
 
 #define NULL 0
 
-#include "platformcode.h"
+#include "support.h"
 
 #ifdef IO
 #include "libp.c"
@@ -286,7 +286,7 @@ int main()
    short int *check_block;
    int to_return;
 
-   initialise_trigger();
+   initialise_board ();
    start_trigger();
 
    for(n = 0; n < REPEAT_FACTOR; ++n)


### PR DESCRIPTION
```
* src/fdct/fdct.c: Use ANSI style comments and 80 column
throughout.  Correct expected value for block[12].  Add GPL header.
(void fdct): Use long int instead of int for all temporaries.
(int main): Use long int where needed.  Add check blocks for 1 and
4096 transformations and use where appropriate.
```
