### PR TITLE
Fix #14. Cast signed strings to unsigned to prevent ctype.h warning

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2014-08-18  James Pallister  <james.pallister@bristol.ac.uk>
+
+	Cast the signed char strings to unsigned char to prevent
+	warnings with newlib's ctype.h
+
+	* src/ctl-string/string.c: Cast the string to unsigned char.
+	* src/slre/slre.c: Cast to unsigned char.
+
 2014-08-14  Andrew Burgess  <andrew.burgess@embecosm.com>
 
 	* analysis/all_stats.py: Add GPL header.

--- a/src/ctl-string/string.c
+++ b/src/ctl-string/string.c
@@ -325,9 +325,9 @@ int ctl_StringCmpNoCase(ctl_string* s, const char* string)
   size_t i=0;
   while(s->string[i]&&string[i])
   {
-    if(tolower(s->string[i])!=tolower(string[i]))
+    if(tolower((unsigned char)s->string[i])!=tolower((unsigned char)string[i]))
     {
-      return tolower(s->string[i])-tolower(string[i]);
+      return tolower((unsigned char)s->string[i])-tolower((unsigned char)string[i]);
     }
     ++i;
   }

--- a/src/slre/slre.c
+++ b/src/slre/slre.c
@@ -182,7 +182,7 @@ static int match_set(const char *re, int re_len, const char *s,
         re[len + 2] != '\0') {
       result = info->flags &&  IGNORE_CASE ?
         *s >= re[len] && *s <= re[len + 2] :
-        tolower(*s) >= tolower(re[len]) && tolower(*s) <= tolower(re[len + 2]);
+        tolower((int)*s) >= tolower((int)re[len]) && tolower((int)*s) <= tolower((int)re[len + 2]);
       len += 3;
     } else {
       result = match_op((unsigned char *) re + len, (unsigned char *) s, info);
@@ -399,8 +399,8 @@ static int foo(const char *re, int re_len, const char *s, int s_len,
         /* Hex digit specification must follow */
         FAIL_IF(re[i + 1] == 'x' && i >= re_len - 3,
                 SLRE_INVALID_METACHARACTER);
-        FAIL_IF(re[i + 1] ==  'x' && !(isxdigit(re[i + 2]) &&
-                isxdigit(re[i + 3])), SLRE_INVALID_METACHARACTER);
+        FAIL_IF(re[i + 1] ==  'x' && !(isxdigit((unsigned char)re[i + 2]) &&
+                isxdigit((unsigned char)re[i + 3])), SLRE_INVALID_METACHARACTER);
       } else {
         FAIL_IF(!is_metacharacter((unsigned char *) re + i + 1),
                 SLRE_INVALID_METACHARACTER);


### PR DESCRIPTION
Fix issue #14 
