### PR TITLE
Added GPL headers to some of the benchmarks for the WCET set.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2014-08-29  James Pallister  <james.pallister@bristol.ac.uk>
+	Added GPL headers to some of the benchmarks for the WCET set.
+
+	* src/cnt/cnt.c: Added GPL header
+	* src/compress/compress.c: Added GPL header
+	* src/duff/duff.c: Added GPL header
+	* src/edn/edn.c: Added GPL header
+	* src/matmult/matmult.c: Added GPL header
+
 2014-08-28  Andrew Burgess  <andrew.burgess@embecosm.com>
 
 	* src/qrduino/qrtest.c: Update GPL header to correct benchmark

--- a/src/cnt/cnt.c
+++ b/src/cnt/cnt.c
@@ -1,3 +1,29 @@
+/* BEEBS cnt benchmark
+
+   Copyright (C) 2014 Embecosm Limited and University of Bristol
+
+   Contributor James Pallister <james.pallister@bristol.ac.uk>
+
+   This file is part of the Bristol/Embecosm Embedded Benchmark Suite.
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program. If not, see <http://www.gnu.org/licenses/>. */
+
+/* Original code from: WCET Benchmarks,
+       http://www.mrtc.mdh.se/projects/wcet/benchmarks.html
+   Permission to license under GPL obtained by email from Björn Lisper
+ */
+
 #include "support.h"
 
 /* This scale factor will be changed to equalise the runtime of the

--- a/src/compress/compress.c
+++ b/src/compress/compress.c
@@ -1,3 +1,29 @@
+/* BEEBS compress benchmark
+
+   Copyright (C) 2014 Embecosm Limited and University of Bristol
+
+   Contributor James Pallister <james.pallister@bristol.ac.uk>
+
+   This file is part of the Bristol/Embecosm Embedded Benchmark Suite.
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program. If not, see <http://www.gnu.org/licenses/>. */
+
+/* Original code from: WCET Benchmarks,
+       http://www.mrtc.mdh.se/projects/wcet/benchmarks.html
+   Permission to license under GPL obtained by email from Björn Lisper
+ */
+
 /* MDH WCET BENCHMARK SUITE. File version $Id: compress.c,v 1.7 2005/12/21 09:37:18 jgn Exp $ */
 
 /*

--- a/src/duff/duff.c
+++ b/src/duff/duff.c
@@ -1,3 +1,29 @@
+/* BEEBS duff benchmark
+
+   Copyright (C) 2014 Embecosm Limited and University of Bristol
+
+   Contributor James Pallister <james.pallister@bristol.ac.uk>
+
+   This file is part of the Bristol/Embecosm Embedded Benchmark Suite.
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program. If not, see <http://www.gnu.org/licenses/>. */
+
+/* Original code from: WCET Benchmarks,
+       http://www.mrtc.mdh.se/projects/wcet/benchmarks.html
+   Permission to license under GPL obtained by email from Björn Lisper
+ */
+
 #include "support.h"
 
 /* This scale factor will be changed to equalise the runtime of the

--- a/src/edn/edn.c
+++ b/src/edn/edn.c
@@ -1,3 +1,29 @@
+/* BEEBS edn benchmark
+
+   Copyright (C) 2014 Embecosm Limited and University of Bristol
+
+   Contributor James Pallister <james.pallister@bristol.ac.uk>
+
+   This file is part of the Bristol/Embecosm Embedded Benchmark Suite.
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program. If not, see <http://www.gnu.org/licenses/>. */
+
+/* Original code from: WCET Benchmarks,
+       http://www.mrtc.mdh.se/projects/wcet/benchmarks.html
+   Permission to license under GPL obtained by email from Björn Lisper
+ */
+
 #include "support.h"
 
 /* This scale factor will be changed to equalise the runtime of the

--- a/src/matmult/matmult.c
+++ b/src/matmult/matmult.c
@@ -1,3 +1,29 @@
+/* BEEBS matmult benchmark
+
+   Copyright (C) 2014 Embecosm Limited and University of Bristol
+
+   Contributor James Pallister <james.pallister@bristol.ac.uk>
+
+   This file is part of the Bristol/Embecosm Embedded Benchmark Suite.
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program. If not, see <http://www.gnu.org/licenses/>. */
+
+/* Original code from: WCET Benchmarks,
+       http://www.mrtc.mdh.se/projects/wcet/benchmarks.html
+   Permission to license under GPL obtained by email from Björn Lisper
+ */
+
 /* $Id: matmult.c,v 1.2 2005/04/04 11:34:58 csg Exp $ */
 
 /* matmult.c */


### PR DESCRIPTION
```
* src/cnt/cnt.c: Added GPL header
* src/compress/compress.c: Added GPL header
* src/duff/duff.c: Added GPL header
* src/edn/edn.c: Added GPL header
* src/matmult/matmult.c: Added GPL header
```
