### PR TITLE
Fix for cubic: reset output counting when doing the repeat

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2014-11-21  James Pallister  <james.pallister@bristol.ac.uk>
+	Fix for cubic: reset output counting when doing the repeat
+
+	* src/cubic/basicmath_small.c: When repeating the benchmark more than
+	    once we need to reset the output count
+
 2014-09-06  Andrew Burgess  <andrew.burgess@embecosm.com>
 
 	* src/dhrystone/dhry_1.c: Add start and stop triggers.

--- a/src/cubic/basicmath_small.c
+++ b/src/cubic/basicmath_small.c
@@ -55,6 +55,9 @@ int main(void)
 
    for(n = 0; n < SCALE_FACTOR; ++n)
    {
+      output_pos = output;
+      output_count = 0;
+
       /* solve some cubic functions */
       /* should get 3 solutions: 2, 6 & 2.5   */
       SolveCubic(a1, b1, c1, d1, &solutions, output);


### PR DESCRIPTION
```
* src/cubic/basicmath_small.c: When repeating the benchmark more
    than once we need to reset the output count
```
