### PR TITLE
Fixed failing test due to even instead of odd constant

### DIFF
--- a/src/aha-mont64/mont64.c
+++ b/src/aha-mont64/mont64.c
@@ -197,11 +197,11 @@ int benchmark() {
    uint64 a, b, m, hr, p1hi, p1lo, p1, p, abar, bbar;
    uint64 phi, plo;
    volatile uint64 rinv, mprime;
-   int errors;
+   int errors = 0;
 
-   m = 0xfae849273928f89eLL;
-   b = 0x14736defb9330573LL;
-   a = 0x0549372187237fefLL;
+   m = 0xfae849273928f89fLL;             // Must be odd.
+   b = 0x14736defb9330573LL;             // Must be smaller than m.
+   a = 0x0549372187237fefLL;             // Must be smaller than m.
 
    /* The simple calculation: This computes (a*b)**4 (mod m) correctly for all a,
    b, m < 2**64. */
@@ -263,7 +263,8 @@ int benchmark() {
 
    mulul64(p, rinv, &phi, &plo);
    p = modul64(phi, plo, m);
-   if (p != p1) errors = 1;
+   if (p != p1) 
+	   errors = 1;
 
    return errors;
 }


### PR DESCRIPTION
The aha-mont64 test was failing because the `m` constant was even instead of odd. [The original hacker's delight code][1] checked for this in the input argument validation. Also, the `errors` variable was uninitialized in the case of success only. 

[1]: https://github.com/lapinnoir/Hackers-Delight/blob/2bcb559da638a97f429c19889e6fd7d8601fd5d2/mont64.c.txt#L208