### PR TITLE
Fix build when ferror is defined as a macro

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2019-03-22  Graham Markall  <graham.markall@embecosm.com>
+
+	* support/dummy-libc.c: Undef ferror if it is defined.
+
 2019-03-19  Graham Markall  <graham.markall@embecosm.com>
 
 	* configure: Regenerate.

--- a/support/dummy-libc.c
+++ b/support/dummy-libc.c
@@ -28,6 +28,13 @@
 #include <time.h>
 #include <stdio.h>
 
+/* Avoid conflict with ferror defined as a macro, which is the case on some
+   systems.  */
+#ifdef ferror
+#undef ferror
+#endif
+
+
 void * __locale_ctype_ptr;
 
 int __errno;


### PR DESCRIPTION
On some systems ferror is a macro. When this is the case,
implementing a function names ferror can result in a syntax error,
similar to:

```
dummy-libc.c:248:1: error: expected identifier or '(' before 'int'
 ferror (FILE *stream __attribute__ ((unused)))
 ^~~~~~
dummy-libc.c:248:1: error: expected ')' before '(' token
 ferror (FILE *stream __attribute__ ((unused)))
```

This commit attempts to remedy the issue by undefining ferror in
dummy-libc.c if it is defined.

ChangeLog:

        * support/dummy-libc.c: Undef ferror if it is defined.