### PR TITLE
Attempt to fix bugs #59, #60 and others.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,173 @@
+2019-03-25  Graham Markall  <graham.markall@embecosm.com>
+
+	* configure: Regenerate.
+	* configure.ac: Add board flags to flags before config checks.
+	* config/arm/chips/nrf51822/chip.ld: Add vector_table entry point.
+	* src/aha-compress/Makefile.am: Drop libmain. Link libsupportfirst.
+	* src/aha-compress/Makefile.in: Regenerate.
+	* src/aha-mont64/Makefile.am: Drop libmain. Link libsupport first.
+	* src/aha-mont64/Makefile.in: Regenerate.
+	* src/bs/Makefile.am: Drop libmain. Link libsupport first.
+	* src/bs/Makefile.in: Regenerate.
+	* src/bubblesort/Makefile.am: Drop libmain. Link libsupport first.
+	* src/bubblesort/Makefile.in: Regenerate.
+	* src/cnt/Makefile.am: Drop libmain. Link libsupport first.
+	* src/cnt/Makefile.in: Regenerate.
+	* src/common.mk.am:
+	* src/compress/Makefile.am: Drop libmain. Link libsupport first.
+	* src/compress/Makefile.in: Regenerate.
+	* src/cover/Makefile.am: Drop libmain. Link libsupport first.
+	* src/cover/Makefile.in: Regenerate.
+	* src/crc/Makefile.am: Drop libmain. Link libsupport first.
+	* src/crc/Makefile.in: Regenerate.
+	* src/crc32/Makefile.am: Drop libmain. Link libsupport first.
+	* src/crc32/Makefile.in: Regenerate.
+	* src/ctl-stack/Makefile.am: Drop libmain. Link libsupport first.
+	* src/ctl-stack/Makefile.in: Regenerate.
+	* src/ctl-string/Makefile.am: Drop libmain. Link libsupport first.
+	* src/ctl-string/Makefile.in: Regenerate.
+	* src/ctl-vector/Makefile.am: Drop libmain. Link libsupport first.
+	* src/ctl-vector/Makefile.in: Regenerate.
+	* src/cubic/Makefile.am: Drop libmain. Link libsupport first.
+	* src/cubic/Makefile.in: Regenerate.
+	* src/dijkstra/Makefile.am: Drop libmain. Link libsupport first.
+	* src/dijkstra/Makefile.in: Regenerate.
+	* src/dtoa/Makefile.am: Drop libmain. Link libsupport first.
+	* src/dtoa/Makefile.in: Regenerate.
+	* src/duff/Makefile.am: Drop libmain. Link libsupport first.
+	* src/duff/Makefile.in: Regenerate.
+	* src/edn/Makefile.am: Drop libmain. Link libsupport first.
+	* src/edn/Makefile.in: Regenerate.
+	* src/expint/Makefile.am: Drop libmain. Link libsupport first.
+	* src/expint/Makefile.in: Regenerate.
+	* src/fac/Makefile.am: Drop libmain. Link libsupport first.
+	* src/fac/Makefile.in: Regenerate.
+	* src/fasta/Makefile.am: Drop libmain. Link libsupport first.
+	* src/fasta/Makefile.in: Regenerate.
+	* src/fdct/Makefile.am: Drop libmain. Link libsupport first.
+	* src/fdct/Makefile.in: Regenerate.
+	* src/fibcall/Makefile.am: Drop libmain. Link libsupport first.
+	* src/fibcall/Makefile.in: Regenerate.
+	* src/fir/Makefile.am: Drop libmain. Link libsupport first.
+	* src/fir/Makefile.in: Regenerate.
+	* src/frac/Makefile.am: Drop libmain. Link libsupport first.
+	* src/frac/Makefile.in: Regenerate.
+	* src/huffbench/Makefile.am: Drop libmain. Link libsupport first.
+	* src/huffbench/Makefile.in: Regenerate.
+	* src/insertsort/Makefile.am: Drop libmain. Link libsupport first.
+	* src/insertsort/Makefile.in: Regenerate.
+	* src/janne_complex/Makefile.am: Drop libmain. Link libsupport first.
+	* src/janne_complex/Makefile.in: Regenerate.
+	* src/jfdctint/Makefile.am: Drop libmain. Link libsupport first.
+	* src/jfdctint/Makefile.in: Regenerate.
+	* src/lcdnum/Makefile.am: Drop libmain. Link libsupport first.
+	* src/lcdnum/Makefile.in: Regenerate.
+	* src/levenshtein/Makefile.am: Drop libmain. Link libsupport first.
+	* src/levenshtein/Makefile.in: Regenerate.
+	* src/ludcmp/Makefile.am: Drop libmain. Link libsupport first.
+	* src/ludcmp/Makefile.in: Regenerate.
+	* src/matmult-float/Makefile.am: Drop libmain. Link libsupport first.
+	* src/matmult-float/Makefile.in: Regenerate.
+	* src/matmult-int/Makefile.am: Drop libmain. Link libsupport first.
+	* src/matmult-int/Makefile.in: Regenerate.
+	* src/mergesort/Makefile.am: Drop libmain. Link libsupport first.
+	* src/mergesort/Makefile.in: Regenerate.
+	* src/miniz/Makefile.am: Drop libmain. Link libsupport first.
+	* src/miniz/Makefile.in: Regenerate.
+	* src/minver/Makefile.am: Drop libmain. Link libsupport first.
+	* src/minver/Makefile.in: Regenerate.
+	* src/nbody/Makefile.am: Drop libmain. Link libsupport first.
+	* src/nbody/Makefile.in: Regenerate.
+	* src/ndes/Makefile.am: Drop libmain. Link libsupport first.
+	* src/ndes/Makefile.in: Regenerate.
+	* src/nettle-arcfour/Makefile.am: Drop libmain. Link libsupport first.
+	* src/nettle-arcfour/Makefile.in: Regenerate.
+	* src/nettle-cast128/Makefile.am: Drop libmain. Link libsupport first.
+	* src/nettle-cast128/Makefile.in: Regenerate.
+	* src/nettle-des/Makefile.am: Drop libmain. Link libsupport first.
+	* src/nettle-des/Makefile.in: Regenerate.
+	* src/nettle-md5/Makefile.am: Drop libmain. Link libsupport first.
+	* src/nettle-md5/Makefile.in: Regenerate.
+	* src/nettle-sha256/Makefile.am: Drop libmain. Link libsupport first.
+	* src/nettle-sha256/Makefile.in: Regenerate.
+	* src/newlib-exp/Makefile.am: Drop libmain. Link libsupport first.
+	* src/newlib-exp/Makefile.in: Regenerate.
+	* src/newlib-log/Makefile.am: Drop libmain. Link libsupport first.
+	* src/newlib-log/Makefile.in: Regenerate.
+	* src/newlib-mod/Makefile.am: Drop libmain. Link libsupport first.
+	* src/newlib-mod/Makefile.in: Regenerate.
+	* src/newlib-sqrt/Makefile.am: Drop libmain. Link libsupport first.
+	* src/newlib-sqrt/Makefile.in: Regenerate.
+	* src/ns/Makefile.am: Drop libmain. Link libsupport first.
+	* src/ns/Makefile.in: Regenerate.
+	* src/nsichneu/Makefile.am: Drop libmain. Link libsupport first.
+	* src/nsichneu/Makefile.in: Regenerate.
+	* src/picojpeg/Makefile.am: Drop libmain. Link libsupport first.
+	* src/picojpeg/Makefile.in: Regenerate.
+	* src/prime/Makefile.am: Drop libmain. Link libsupport first.
+	* src/prime/Makefile.in: Regenerate.
+	* src/qrduino/Makefile.am: Drop libmain. Link libsupport first.
+	* src/qrduino/Makefile.in: Regenerate.
+	* src/qsort/Makefile.am: Drop libmain. Link libsupport first.
+	* src/qsort/Makefile.in: Regenerate.
+	* src/qurt/Makefile.am: Drop libmain. Link libsupport first.
+	* src/qurt/Makefile.in: Regenerate.
+	* src/recursion/Makefile.am: Drop libmain. Link libsupport first.
+	* src/recursion/Makefile.in: Regenerate.
+	* src/rijndael/Makefile.am: Drop libmain. Link libsupport first.
+	* src/rijndael/Makefile.in: Regenerate.
+	* src/select/Makefile.am: Drop libmain. Link libsupport first.
+	* src/select/Makefile.in: Regenerate.
+	* src/sglib-arraybinsearch/Makefile.am: Drop libmain. Link libsupport first.
+	* src/sglib-arraybinsearch/Makefile.in: Regenerate.
+	* src/sglib-arrayheapsort/Makefile.am: Drop libmain. Link libsupport first.
+	* src/sglib-arrayheapsort/Makefile.in: Regenerate.
+	* src/sglib-arrayquicksort/Makefile.am: Drop libmain. Link libsupport first.
+	* src/sglib-arrayquicksort/Makefile.in: Regenerate.
+	* src/sglib-dllist/Makefile.am: Drop libmain. Link libsupport first.
+	* src/sglib-dllist/Makefile.in: Regenerate.
+	* src/sglib-hashtable/Makefile.am: Drop libmain. Link libsupport first.
+	* src/sglib-hashtable/Makefile.in: Regenerate.
+	* src/sglib-listinsertsort/Makefile.am: Drop libmain. Link libsupport first.
+	* src/sglib-listinsertsort/Makefile.in: Regenerate.
+	* src/sglib-listsort/Makefile.am: Drop libmain. Link libsupport first.
+	* src/sglib-listsort/Makefile.in: Regenerate.
+	* src/sglib-queue/Makefile.am: Drop libmain. Link libsupport first.
+	* src/sglib-queue/Makefile.in: Regenerate.
+	* src/sglib-rbtree/Makefile.am: Drop libmain. Link libsupport first.
+	* src/sglib-rbtree/Makefile.in: Regenerate.
+	* src/slre/Makefile.am: Drop libmain. Link libsupport first.
+	* src/slre/Makefile.in: Regenerate.
+	* src/sqrt/Makefile.am: Drop libmain. Link libsupport first.
+	* src/sqrt/Makefile.in: Regenerate.
+	* src/st/Makefile.am: Drop libmain. Link libsupport first.
+	* src/st/Makefile.in: Regenerate.
+	* src/statemate/Makefile.am: Drop libmain. Link libsupport first.
+	* src/statemate/Makefile.in: Regenerate.
+	* src/stb_perlin/Makefile.am: Drop libmain. Link libsupport first.
+	* src/stb_perlin/Makefile.in: Regenerate.
+	* src/stringsearch1/Makefile.am: Drop libmain. Link libsupport first.
+	* src/stringsearch1/Makefile.in: Regenerate.
+	* src/strstr/Makefile.am: Drop libmain. Link libsupport first.
+	* src/strstr/Makefile.in: Regenerate.
+	* src/tarai/Makefile.am: Drop libmain. Link libsupport first.
+	* src/tarai/Makefile.in: Regenerate.
+	* src/template/Makefile.am: Drop libmain. Link libsupport first.
+	* src/template/Makefile.in: Regenerate.
+	* src/trio-snprintf/Makefile.am: Drop libmain. Link libsupport first.
+	* src/trio-snprintf/Makefile.in: Regenerate.
+	* src/trio-sscanf/Makefile.am: Drop libmain. Link libsupport first.
+	* src/trio-sscanf/Makefile.in: Regenerate.
+	* src/ud/Makefile.am: Drop libmain. Link libsupport first.
+	* src/ud/Makefile.in: Regenerate.
+	* src/whetstone/Makefile.am: Drop libmain. Link libsupport first.
+	* src/whetstone/Makefile.in: Regenerate.
+	* src/wikisort/Makefile.am: Drop libmain. Link libsupport first.
+	* src/wikisort/Makefile.in: Regenerate.
+	* support/Makefile.am: Drop libmain. Put main.c in libsupport.
+	* support/Makefile.in: Regenerate.
+	* support/chip.c: Include config.h
+
 2019-03-22  Graham Markall  <graham.markall@embecosm.com>
 
 	* support/dummy-libc.c: Undef ferror if it is defined.

--- a/config/arm/chips/nrf51822/chip.ld
+++ b/config/arm/chips/nrf51822/chip.ld
@@ -23,6 +23,13 @@
 * Modified by lbogdanov@tu-sofia.bg to support heap
 */
 
+/* The entry point is not strictly the beginning of the vector table, but
+ * setting it as the entry point at least forces it and all relocations present
+ * in it to be included. The entry point is not used by the board/loader so it
+ * doesn't cause execution to start at the wrong address.
+ */
+ENTRY(vector_table)
+
 MEMORY
 {
     FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 256K /* FLASH size 256KB */

--- a/configure
+++ b/configure
@@ -653,6 +653,47 @@ am__fastdepCCAS_TRUE
 CCASDEPMODE
 CCASFLAGS
 CCAS
+LIBTOOL_DEPS
+CPP
+LT_SYS_LIBRARY_PATH
+OTOOL64
+OTOOL
+LIPO
+NMEDIT
+DSYMUTIL
+MANIFEST_TOOL
+RANLIB
+ac_ct_AR
+AR
+DLLTOOL
+OBJDUMP
+LN_S
+NM
+ac_ct_DUMPBIN
+DUMPBIN
+LD
+FGREP
+EGREP
+GREP
+SED
+am__fastdepCC_FALSE
+am__fastdepCC_TRUE
+CCDEPMODE
+am__nodep
+AMDEPBACKSLASH
+AMDEP_FALSE
+AMDEP_TRUE
+am__quote
+am__include
+DEPDIR
+OBJEXT
+EXEEXT
+ac_ct_CC
+CPPFLAGS
+LDFLAGS
+CFLAGS
+CC
+LIBTOOL
 CALIBRATION_FALSE
 CALIBRATION_TRUE
 CHIPSUPPORT_C_FALSE
@@ -817,47 +858,6 @@ ENABLED_BENCHMARK_AHA_MONT64_FALSE
 ENABLED_BENCHMARK_AHA_MONT64_TRUE
 ENABLED_BENCHMARK_AHA_COMPRESS_FALSE
 ENABLED_BENCHMARK_AHA_COMPRESS_TRUE
-LIBTOOL_DEPS
-CPP
-LT_SYS_LIBRARY_PATH
-OTOOL64
-OTOOL
-LIPO
-NMEDIT
-DSYMUTIL
-MANIFEST_TOOL
-RANLIB
-ac_ct_AR
-AR
-DLLTOOL
-OBJDUMP
-LN_S
-NM
-ac_ct_DUMPBIN
-DUMPBIN
-LD
-FGREP
-EGREP
-GREP
-SED
-am__fastdepCC_FALSE
-am__fastdepCC_TRUE
-CCDEPMODE
-am__nodep
-AMDEPBACKSLASH
-AMDEP_FALSE
-AMDEP_TRUE
-am__quote
-am__include
-DEPDIR
-OBJEXT
-EXEEXT
-ac_ct_CC
-CPPFLAGS
-LDFLAGS
-CFLAGS
-CC
-LIBTOOL
 MAINT
 MAINTAINER_MODE_FALSE
 MAINTAINER_MODE_TRUE
@@ -943,15 +943,6 @@ ac_user_opts='
 enable_option_checking
 enable_silent_rules
 enable_maintainer_mode
-enable_shared
-enable_static
-with_pic
-enable_fast_install
-with_aix_soname
-enable_dependency_tracking
-with_gnu_ld
-with_sysroot
-enable_libtool_lock
 with_board
 with_chip
 enable_benchmark_aha_compress
@@ -1034,6 +1025,15 @@ enable_benchmark_trio_sscanf
 enable_benchmark_ud
 enable_benchmark_whetstone
 enable_benchmark_wikisort
+enable_shared
+enable_static
+with_pic
+enable_fast_install
+with_aix_soname
+enable_dependency_tracking
+with_gnu_ld
+with_sysroot
+enable_libtool_lock
 '
       ac_precious_vars='build_alias
 host_alias
@@ -1671,15 +1671,6 @@ Optional Features:
   --enable-maintainer-mode
                           enable make rules and dependencies not useful (and
                           sometimes confusing) to the casual installer
-  --enable-shared[=PKGS]  build shared libraries [default=yes]
-  --enable-static[=PKGS]  build static libraries [default=yes]
-  --enable-fast-install[=PKGS]
-                          optimize for fast installation [default=yes]
-  --enable-dependency-tracking
-                          do not reject slow dependency extractors
-  --disable-dependency-tracking
-                          speeds up one-time build
-  --disable-libtool-lock  avoid locking (might break parallel builds)
   --enable-benchmark-aha-compress
                           Enable benchmark aha-compress
   --enable-benchmark-aha-mont64
@@ -1823,10 +1814,21 @@ Optional Features:
                           Enable benchmark whetstone
   --enable-benchmark-wikisort
                           Enable benchmark wikisort
+  --enable-shared[=PKGS]  build shared libraries [default=yes]
+  --enable-static[=PKGS]  build static libraries [default=yes]
+  --enable-fast-install[=PKGS]
+                          optimize for fast installation [default=yes]
+  --enable-dependency-tracking
+                          do not reject slow dependency extractors
+  --disable-dependency-tracking
+                          speeds up one-time build
+  --disable-libtool-lock  avoid locking (might break parallel builds)
 
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
+  --with-board            Select the board to target
+  --with-chip             Select the chip to target
   --with-pic[=PKGS]       try to use only PIC/non-PIC objects [default=use
                           both]
   --with-aix-soname=aix|svr4|both
@@ -1835,8 +1837,6 @@ Optional Packages:
   --with-gnu-ld           assume the C compiler uses GNU ld [default=no]
   --with-sysroot[=DIR]    Search for dependent libraries within DIR (or the
                           compiler's sysroot if not specified).
-  --with-board            Select the board to target
-  --with-chip             Select the chip to target
 
 Some influential environment variables:
   CC          C compiler command
@@ -3327,6 +3327,1783 @@ else
 fi
 AM_BACKSLASH='\'
 
+
+# List of all benchmarks
+
+bmlist="aha-compress          \
+        aha-mont64            \
+        bs                    \
+        bubblesort            \
+        cnt                   \
+        compress              \
+        cover                 \
+        crc                   \
+        crc32                 \
+        ctl                   \
+        ctl-stack             \
+        ctl-string            \
+        ctl-vector            \
+        cubic                 \
+        dijkstra              \
+        dtoa                  \
+        duff                  \
+        edn                   \
+        expint                \
+        fac                   \
+        fasta                 \
+        fdct                  \
+        fibcall               \
+        fir                   \
+        frac                  \
+        huffbench             \
+        insertsort            \
+        janne_complex         \
+        jfdctint              \
+        lcdnum                \
+        levenshtein           \
+        ludcmp                \
+        matmult               \
+        matmult-float         \
+        matmult-int           \
+        mergesort             \
+        miniz                 \
+        minver                \
+        nbody                 \
+        ndes                  \
+        nettle-arcfour        \
+        nettle-cast128        \
+        nettle-des            \
+        nettle-md5            \
+        nettle-sha256         \
+        newlib-exp            \
+        newlib-log            \
+        newlib-mod            \
+        newlib-sqrt           \
+        ns                    \
+        nsichneu              \
+        picojpeg              \
+        prime                 \
+        qrduino               \
+        qsort                 \
+        qurt                  \
+        recursion             \
+        rijndael              \
+        select                \
+        sglib-arraybinsearch  \
+        sglib-arrayheapsort   \
+        sglib-arrayquicksort  \
+        sglib-arraysort       \
+        sglib-dllist          \
+        sglib-hashtable       \
+        sglib-listinsertsort  \
+        sglib-listsort        \
+        sglib-queue           \
+        sglib-rbtree          \
+        slre                  \
+        sqrt                  \
+        st                    \
+        statemate             \
+        stb_perlin            \
+        stringsearch1         \
+        strstr                \
+        tarai                 \
+        template              \
+        trio                  \
+        trio-snprintf         \
+        trio-sscanf           \
+        ud                    \
+        whetstone             \
+        wikisort"
+
+# Set default values enabling all architectures
+
+benchmark_aha_compress=true
+benchmark_aha_mont64=true
+benchmark_bs=true
+benchmark_bubblesort=true
+benchmark_cnt=true
+benchmark_compress=true
+benchmark_cover=true
+benchmark_crc=true
+benchmark_crc32=true
+benchmark_ctl_stack=true
+benchmark_ctl_string=true
+benchmark_ctl_vector=true
+benchmark_cubic=true
+benchmark_dijkstra=true
+benchmark_dtoa=true
+benchmark_duff=true
+benchmark_edn=true
+benchmark_expint=true
+benchmark_fac=true
+benchmark_fasta=true
+benchmark_fdct=true
+benchmark_fibcall=true
+benchmark_fir=true
+benchmark_frac=true
+benchmark_huffbench=true
+benchmark_insertsort=true
+benchmark_janne_complex=true
+benchmark_jfdctint=true
+benchmark_lcdnum=true
+benchmark_levenshtein=true
+benchmark_ludcmp=true
+benchmark_matmult_float=true
+benchmark_matmult_int=true
+benchmark_mergesort=true
+benchmark_miniz=true
+benchmark_minver=true
+benchmark_nbody=true
+benchmark_ndes=true
+benchmark_nettle_arcfour=true
+benchmark_nettle_cast128=true
+benchmark_nettle_des=true
+benchmark_nettle_md5=true
+benchmark_nettle_sha256=true
+benchmark_newlib_exp=true
+benchmark_newlib_log=true
+benchmark_newlib_mod=true
+benchmark_newlib_sqrt=true
+benchmark_ns=true
+benchmark_nsichneu=true
+benchmark_picojpeg=true
+benchmark_prime=true
+benchmark_qrduino=true
+benchmark_qsort=true
+benchmark_qurt=true
+benchmark_recursion=true
+benchmark_rijndael=true
+benchmark_select=true
+benchmark_sglib_arraybinsearch=true
+benchmark_sglib_arrayheapsort=true
+benchmark_sglib_arrayquicksort=true
+benchmark_sglib_dllist=true
+benchmark_sglib_hashtable=true
+benchmark_sglib_listinsertsort=true
+benchmark_sglib_listsort=true
+benchmark_sglib_queue=true
+benchmark_sglib_rbtree=true
+benchmark_slre=true
+benchmark_sqrt=true
+benchmark_st=true
+benchmark_statemate=true
+benchmark_stb_perlin=true
+benchmark_stringsearch1=true
+benchmark_strstr=true
+benchmark_tarai=true
+benchmark_template=true
+benchmark_trio_snprintf=true
+benchmark_trio_sscanf=true
+benchmark_ud=true
+benchmark_whetstone=true
+benchmark_wikisort=true
+
+# Work out which architecture we are targeting
+# Also pass this through to be substituted
+
+arch=$host_cpu
+
+# Option for selecting the target board
+
+
+# Check whether --with-board was given.
+if test "${with_board+set}" = set; then :
+  withval=$with_board; board=$with_board
+else
+  board=none
+fi
+
+
+# Option for selecting the target chip
+
+
+# Check whether --with-chip was given.
+if test "${with_chip+set}" = set; then :
+  withval=$with_chip; chip=$with_chip
+else
+  chip=generic
+fi
+
+
+# Default settings for dummy libraries. These can be overridden by the
+# chip configuration or configure flags. We default to having them all
+# off because we expect the default setup to produce compiled code that
+# can actually be executed - however, the dummy libraries are helpful
+# for analysing code size without library code inclusion confounding
+# things.
+
+USE_DUMMY_CRT0=no
+USE_DUMMY_LIBGCC=no
+USE_DUMMY_COMPILERRT=no
+USE_DUMMY_LIBC=no
+USE_DUMMY_LIBM=no
+
+# Execute any architecture, board or chip specific configuration. These can
+# set architecture, chip and board CPPFLAGS, CFLAGS and LDFLAGS and exclude
+# individual tests by setting benchmark_<bm> to false.
+
+# We can't use AC_CHECK_FILE, because we are cross-compiling, and that
+# prohibits use of AC_CHECK_FILE.
+
+if test -f $srcdir/config/$arch/arch.cfg; then :
+  source $srcdir/config/$arch/arch.cfg
+fi
+
+if test -d $srcdir/config/$arch/chips/$chip; then :
+
+else
+  as_fn_error $? "Chip config directory \"$chip\" does not exist" "$LINENO" 5
+fi
+
+if test -f $srcdir/config/$arch/chips/$chip/chip.cfg; then :
+  source $srcdir/config/$arch/chips/$chip/chip.cfg
+fi
+
+if test -d $srcdir/config/$arch/boards/$board; then :
+
+else
+  as_fn_error $? "Board config directory \"$board\" does not exist" "$LINENO" 5
+fi
+
+if test -f $srcdir/config/$arch/boards/$board/board.cfg ; then :
+  source $srcdir/config/$arch/boards/$board/board.cfg
+fi
+
+# Options for enabling/disabling each test in alphabetical order (see
+# genmacros.sh for a script to generate all of this). To add one new test just
+# insert the same pattern at the correct place in the list.
+
+# Remember that ctl, matmult, sglib-arraysort and trio are not benchmarks
+# themselves, but the frameworks from which others are created.
+
+# NOTE. There is the m4_foreach macro, but getting it to work for this seems to
+# be impossible
+
+# Check whether --enable-benchmark-aha-compress was given.
+if test "${enable_benchmark_aha_compress+set}" = set; then :
+  enableval=$enable_benchmark_aha_compress; case "${enableval}" in
+      yes) benchmark_aha_compress=true ;;
+      no)  benchmark_aha_compress=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-aha-compress" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_aha_compress = xtrue; then
+  ENABLED_BENCHMARK_AHA_COMPRESS_TRUE=
+  ENABLED_BENCHMARK_AHA_COMPRESS_FALSE='#'
+else
+  ENABLED_BENCHMARK_AHA_COMPRESS_TRUE='#'
+  ENABLED_BENCHMARK_AHA_COMPRESS_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-aha-mont64 was given.
+if test "${enable_benchmark_aha_mont64+set}" = set; then :
+  enableval=$enable_benchmark_aha_mont64; case "${enableval}" in
+      yes) benchmark_aha_mont64=true ;;
+      no)  benchmark_aha_mont64=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-aha-mont64" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_aha_mont64 = xtrue; then
+  ENABLED_BENCHMARK_AHA_MONT64_TRUE=
+  ENABLED_BENCHMARK_AHA_MONT64_FALSE='#'
+else
+  ENABLED_BENCHMARK_AHA_MONT64_TRUE='#'
+  ENABLED_BENCHMARK_AHA_MONT64_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-bs was given.
+if test "${enable_benchmark_bs+set}" = set; then :
+  enableval=$enable_benchmark_bs; case "${enableval}" in
+      yes) benchmark_bs=true ;;
+      no)  benchmark_bs=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-bs" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_bs = xtrue; then
+  ENABLED_BENCHMARK_BS_TRUE=
+  ENABLED_BENCHMARK_BS_FALSE='#'
+else
+  ENABLED_BENCHMARK_BS_TRUE='#'
+  ENABLED_BENCHMARK_BS_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-bubblesort was given.
+if test "${enable_benchmark_bubblesort+set}" = set; then :
+  enableval=$enable_benchmark_bubblesort; case "${enableval}" in
+      yes) benchmark_bubblesort=true ;;
+      no)  benchmark_bubblesort=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-bubblesort" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_bubblesort = xtrue; then
+  ENABLED_BENCHMARK_BUBBLESORT_TRUE=
+  ENABLED_BENCHMARK_BUBBLESORT_FALSE='#'
+else
+  ENABLED_BENCHMARK_BUBBLESORT_TRUE='#'
+  ENABLED_BENCHMARK_BUBBLESORT_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-cnt was given.
+if test "${enable_benchmark_cnt+set}" = set; then :
+  enableval=$enable_benchmark_cnt; case "${enableval}" in
+      yes) benchmark_cnt=true ;;
+      no)  benchmark_cnt=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-cnt" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_cnt = xtrue; then
+  ENABLED_BENCHMARK_CNT_TRUE=
+  ENABLED_BENCHMARK_CNT_FALSE='#'
+else
+  ENABLED_BENCHMARK_CNT_TRUE='#'
+  ENABLED_BENCHMARK_CNT_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-compress was given.
+if test "${enable_benchmark_compress+set}" = set; then :
+  enableval=$enable_benchmark_compress; case "${enableval}" in
+      yes) benchmark_compress=true ;;
+      no)  benchmark_compress=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-compress" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_compress = xtrue; then
+  ENABLED_BENCHMARK_COMPRESS_TRUE=
+  ENABLED_BENCHMARK_COMPRESS_FALSE='#'
+else
+  ENABLED_BENCHMARK_COMPRESS_TRUE='#'
+  ENABLED_BENCHMARK_COMPRESS_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-cover was given.
+if test "${enable_benchmark_cover+set}" = set; then :
+  enableval=$enable_benchmark_cover; case "${enableval}" in
+      yes) benchmark_cover=true ;;
+      no)  benchmark_cover=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-cover" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_cover = xtrue; then
+  ENABLED_BENCHMARK_COVER_TRUE=
+  ENABLED_BENCHMARK_COVER_FALSE='#'
+else
+  ENABLED_BENCHMARK_COVER_TRUE='#'
+  ENABLED_BENCHMARK_COVER_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-crc was given.
+if test "${enable_benchmark_crc+set}" = set; then :
+  enableval=$enable_benchmark_crc; case "${enableval}" in
+      yes) benchmark_crc=true ;;
+      no)  benchmark_crc=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-crc" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_crc = xtrue; then
+  ENABLED_BENCHMARK_CRC_TRUE=
+  ENABLED_BENCHMARK_CRC_FALSE='#'
+else
+  ENABLED_BENCHMARK_CRC_TRUE='#'
+  ENABLED_BENCHMARK_CRC_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-crc32 was given.
+if test "${enable_benchmark_crc32+set}" = set; then :
+  enableval=$enable_benchmark_crc32; case "${enableval}" in
+      yes) benchmark_crc32=true ;;
+      no)  benchmark_crc32=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-crc32" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_crc32 = xtrue; then
+  ENABLED_BENCHMARK_CRC32_TRUE=
+  ENABLED_BENCHMARK_CRC32_FALSE='#'
+else
+  ENABLED_BENCHMARK_CRC32_TRUE='#'
+  ENABLED_BENCHMARK_CRC32_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-ctl-stack was given.
+if test "${enable_benchmark_ctl_stack+set}" = set; then :
+  enableval=$enable_benchmark_ctl_stack; case "${enableval}" in
+      yes) benchmark_ctl_stack=true ;;
+      no)  benchmark_ctl_stack=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-ctl-stack" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_ctl_stack = xtrue; then
+  ENABLED_BENCHMARK_CTL_STACK_TRUE=
+  ENABLED_BENCHMARK_CTL_STACK_FALSE='#'
+else
+  ENABLED_BENCHMARK_CTL_STACK_TRUE='#'
+  ENABLED_BENCHMARK_CTL_STACK_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-ctl-string was given.
+if test "${enable_benchmark_ctl_string+set}" = set; then :
+  enableval=$enable_benchmark_ctl_string; case "${enableval}" in
+      yes) benchmark_ctl_string=true ;;
+      no)  benchmark_ctl_string=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-ctl-string" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_ctl_string = xtrue; then
+  ENABLED_BENCHMARK_CTL_STRING_TRUE=
+  ENABLED_BENCHMARK_CTL_STRING_FALSE='#'
+else
+  ENABLED_BENCHMARK_CTL_STRING_TRUE='#'
+  ENABLED_BENCHMARK_CTL_STRING_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-ctl-vector was given.
+if test "${enable_benchmark_ctl_vector+set}" = set; then :
+  enableval=$enable_benchmark_ctl_vector; case "${enableval}" in
+      yes) benchmark_ctl_vector=true ;;
+      no)  benchmark_ctl_vector=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-ctl-vector" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_ctl_vector = xtrue; then
+  ENABLED_BENCHMARK_CTL_VECTOR_TRUE=
+  ENABLED_BENCHMARK_CTL_VECTOR_FALSE='#'
+else
+  ENABLED_BENCHMARK_CTL_VECTOR_TRUE='#'
+  ENABLED_BENCHMARK_CTL_VECTOR_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-cubic was given.
+if test "${enable_benchmark_cubic+set}" = set; then :
+  enableval=$enable_benchmark_cubic; case "${enableval}" in
+      yes) benchmark_cubic=true ;;
+      no)  benchmark_cubic=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-cubic" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_cubic = xtrue; then
+  ENABLED_BENCHMARK_CUBIC_TRUE=
+  ENABLED_BENCHMARK_CUBIC_FALSE='#'
+else
+  ENABLED_BENCHMARK_CUBIC_TRUE='#'
+  ENABLED_BENCHMARK_CUBIC_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-dijkstra was given.
+if test "${enable_benchmark_dijkstra+set}" = set; then :
+  enableval=$enable_benchmark_dijkstra; case "${enableval}" in
+      yes) benchmark_dijkstra=true ;;
+      no)  benchmark_dijkstra=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-dijkstra" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_dijkstra = xtrue; then
+  ENABLED_BENCHMARK_DIJKSTRA_TRUE=
+  ENABLED_BENCHMARK_DIJKSTRA_FALSE='#'
+else
+  ENABLED_BENCHMARK_DIJKSTRA_TRUE='#'
+  ENABLED_BENCHMARK_DIJKSTRA_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-dtoa was given.
+if test "${enable_benchmark_dtoa+set}" = set; then :
+  enableval=$enable_benchmark_dtoa; case "${enableval}" in
+      yes) benchmark_dtoa=true ;;
+      no)  benchmark_dtoa=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-dtoa" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_dtoa = xtrue; then
+  ENABLED_BENCHMARK_DTOA_TRUE=
+  ENABLED_BENCHMARK_DTOA_FALSE='#'
+else
+  ENABLED_BENCHMARK_DTOA_TRUE='#'
+  ENABLED_BENCHMARK_DTOA_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-duff was given.
+if test "${enable_benchmark_duff+set}" = set; then :
+  enableval=$enable_benchmark_duff; case "${enableval}" in
+      yes) benchmark_duff=true ;;
+      no)  benchmark_duff=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-duff" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_duff = xtrue; then
+  ENABLED_BENCHMARK_DUFF_TRUE=
+  ENABLED_BENCHMARK_DUFF_FALSE='#'
+else
+  ENABLED_BENCHMARK_DUFF_TRUE='#'
+  ENABLED_BENCHMARK_DUFF_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-edn was given.
+if test "${enable_benchmark_edn+set}" = set; then :
+  enableval=$enable_benchmark_edn; case "${enableval}" in
+      yes) benchmark_edn=true ;;
+      no)  benchmark_edn=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-edn" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_edn = xtrue; then
+  ENABLED_BENCHMARK_EDN_TRUE=
+  ENABLED_BENCHMARK_EDN_FALSE='#'
+else
+  ENABLED_BENCHMARK_EDN_TRUE='#'
+  ENABLED_BENCHMARK_EDN_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-expint was given.
+if test "${enable_benchmark_expint+set}" = set; then :
+  enableval=$enable_benchmark_expint; case "${enableval}" in
+      yes) benchmark_expint=true ;;
+      no)  benchmark_expint=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-expint" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_expint = xtrue; then
+  ENABLED_BENCHMARK_EXPINT_TRUE=
+  ENABLED_BENCHMARK_EXPINT_FALSE='#'
+else
+  ENABLED_BENCHMARK_EXPINT_TRUE='#'
+  ENABLED_BENCHMARK_EXPINT_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-fac was given.
+if test "${enable_benchmark_fac+set}" = set; then :
+  enableval=$enable_benchmark_fac; case "${enableval}" in
+      yes) benchmark_fac=true ;;
+      no)  benchmark_fac=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-fac" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_fac = xtrue; then
+  ENABLED_BENCHMARK_FAC_TRUE=
+  ENABLED_BENCHMARK_FAC_FALSE='#'
+else
+  ENABLED_BENCHMARK_FAC_TRUE='#'
+  ENABLED_BENCHMARK_FAC_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-fasta was given.
+if test "${enable_benchmark_fasta+set}" = set; then :
+  enableval=$enable_benchmark_fasta; case "${enableval}" in
+      yes) benchmark_fasta=true ;;
+      no)  benchmark_fasta=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-fasta" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_fasta = xtrue; then
+  ENABLED_BENCHMARK_FASTA_TRUE=
+  ENABLED_BENCHMARK_FASTA_FALSE='#'
+else
+  ENABLED_BENCHMARK_FASTA_TRUE='#'
+  ENABLED_BENCHMARK_FASTA_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-fdct was given.
+if test "${enable_benchmark_fdct+set}" = set; then :
+  enableval=$enable_benchmark_fdct; case "${enableval}" in
+      yes) benchmark_fdct=true ;;
+      no)  benchmark_fdct=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-fdct" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_fdct = xtrue; then
+  ENABLED_BENCHMARK_FDCT_TRUE=
+  ENABLED_BENCHMARK_FDCT_FALSE='#'
+else
+  ENABLED_BENCHMARK_FDCT_TRUE='#'
+  ENABLED_BENCHMARK_FDCT_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-fibcall was given.
+if test "${enable_benchmark_fibcall+set}" = set; then :
+  enableval=$enable_benchmark_fibcall; case "${enableval}" in
+      yes) benchmark_fibcall=true ;;
+      no)  benchmark_fibcall=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-fibcall" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_fibcall = xtrue; then
+  ENABLED_BENCHMARK_FIBCALL_TRUE=
+  ENABLED_BENCHMARK_FIBCALL_FALSE='#'
+else
+  ENABLED_BENCHMARK_FIBCALL_TRUE='#'
+  ENABLED_BENCHMARK_FIBCALL_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-fir was given.
+if test "${enable_benchmark_fir+set}" = set; then :
+  enableval=$enable_benchmark_fir; case "${enableval}" in
+      yes) benchmark_fir=true ;;
+      no)  benchmark_fir=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-fir" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_fir = xtrue; then
+  ENABLED_BENCHMARK_FIR_TRUE=
+  ENABLED_BENCHMARK_FIR_FALSE='#'
+else
+  ENABLED_BENCHMARK_FIR_TRUE='#'
+  ENABLED_BENCHMARK_FIR_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-frac was given.
+if test "${enable_benchmark_frac+set}" = set; then :
+  enableval=$enable_benchmark_frac; case "${enableval}" in
+      yes) benchmark_frac=true ;;
+      no)  benchmark_frac=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-frac" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_frac = xtrue; then
+  ENABLED_BENCHMARK_FRAC_TRUE=
+  ENABLED_BENCHMARK_FRAC_FALSE='#'
+else
+  ENABLED_BENCHMARK_FRAC_TRUE='#'
+  ENABLED_BENCHMARK_FRAC_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-huffbench was given.
+if test "${enable_benchmark_huffbench+set}" = set; then :
+  enableval=$enable_benchmark_huffbench; case "${enableval}" in
+      yes) benchmark_huffbench=true ;;
+      no)  benchmark_huffbench=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-huffbench" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_huffbench = xtrue; then
+  ENABLED_BENCHMARK_HUFFBENCH_TRUE=
+  ENABLED_BENCHMARK_HUFFBENCH_FALSE='#'
+else
+  ENABLED_BENCHMARK_HUFFBENCH_TRUE='#'
+  ENABLED_BENCHMARK_HUFFBENCH_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-insertsort was given.
+if test "${enable_benchmark_insertsort+set}" = set; then :
+  enableval=$enable_benchmark_insertsort; case "${enableval}" in
+      yes) benchmark_insertsort=true ;;
+      no)  benchmark_insertsort=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-insertsort" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_insertsort = xtrue; then
+  ENABLED_BENCHMARK_INSERTSORT_TRUE=
+  ENABLED_BENCHMARK_INSERTSORT_FALSE='#'
+else
+  ENABLED_BENCHMARK_INSERTSORT_TRUE='#'
+  ENABLED_BENCHMARK_INSERTSORT_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-janne_complex was given.
+if test "${enable_benchmark_janne_complex+set}" = set; then :
+  enableval=$enable_benchmark_janne_complex; case "${enableval}" in
+      yes) benchmark_janne_complex=true ;;
+      no)  benchmark_janne_complex=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-janne_complex" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_janne_complex = xtrue; then
+  ENABLED_BENCHMARK_JANNE_COMPLEX_TRUE=
+  ENABLED_BENCHMARK_JANNE_COMPLEX_FALSE='#'
+else
+  ENABLED_BENCHMARK_JANNE_COMPLEX_TRUE='#'
+  ENABLED_BENCHMARK_JANNE_COMPLEX_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-jfdctint was given.
+if test "${enable_benchmark_jfdctint+set}" = set; then :
+  enableval=$enable_benchmark_jfdctint; case "${enableval}" in
+      yes) benchmark_jfdctint=true ;;
+      no)  benchmark_jfdctint=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-jfdctint" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_jfdctint = xtrue; then
+  ENABLED_BENCHMARK_JFDCTINT_TRUE=
+  ENABLED_BENCHMARK_JFDCTINT_FALSE='#'
+else
+  ENABLED_BENCHMARK_JFDCTINT_TRUE='#'
+  ENABLED_BENCHMARK_JFDCTINT_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-lcdnum was given.
+if test "${enable_benchmark_lcdnum+set}" = set; then :
+  enableval=$enable_benchmark_lcdnum; case "${enableval}" in
+      yes) benchmark_lcdnum=true ;;
+      no)  benchmark_lcdnum=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-lcdnum" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_lcdnum = xtrue; then
+  ENABLED_BENCHMARK_LCDNUM_TRUE=
+  ENABLED_BENCHMARK_LCDNUM_FALSE='#'
+else
+  ENABLED_BENCHMARK_LCDNUM_TRUE='#'
+  ENABLED_BENCHMARK_LCDNUM_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-levenshtein was given.
+if test "${enable_benchmark_levenshtein+set}" = set; then :
+  enableval=$enable_benchmark_levenshtein; case "${enableval}" in
+      yes) benchmark_levenshtein=true ;;
+      no)  benchmark_levenshtein=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-levenshtein" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_levenshtein = xtrue; then
+  ENABLED_BENCHMARK_LEVENSHTEIN_TRUE=
+  ENABLED_BENCHMARK_LEVENSHTEIN_FALSE='#'
+else
+  ENABLED_BENCHMARK_LEVENSHTEIN_TRUE='#'
+  ENABLED_BENCHMARK_LEVENSHTEIN_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-ludcmp was given.
+if test "${enable_benchmark_ludcmp+set}" = set; then :
+  enableval=$enable_benchmark_ludcmp; case "${enableval}" in
+      yes) benchmark_ludcmp=true ;;
+      no)  benchmark_ludcmp=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-ludcmp" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_ludcmp = xtrue; then
+  ENABLED_BENCHMARK_LUDCMP_TRUE=
+  ENABLED_BENCHMARK_LUDCMP_FALSE='#'
+else
+  ENABLED_BENCHMARK_LUDCMP_TRUE='#'
+  ENABLED_BENCHMARK_LUDCMP_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-matmult-float was given.
+if test "${enable_benchmark_matmult_float+set}" = set; then :
+  enableval=$enable_benchmark_matmult_float; case "${enableval}" in
+      yes) benchmark_matmult_float=true ;;
+      no)  benchmark_matmult_float=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-matmult-float" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_matmult_float = xtrue; then
+  ENABLED_BENCHMARK_MATMULT_FLOAT_TRUE=
+  ENABLED_BENCHMARK_MATMULT_FLOAT_FALSE='#'
+else
+  ENABLED_BENCHMARK_MATMULT_FLOAT_TRUE='#'
+  ENABLED_BENCHMARK_MATMULT_FLOAT_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-matmult-int was given.
+if test "${enable_benchmark_matmult_int+set}" = set; then :
+  enableval=$enable_benchmark_matmult_int; case "${enableval}" in
+      yes) benchmark_matmult_int=true ;;
+      no)  benchmark_matmult_int=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-matmult-int" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_matmult_int = xtrue; then
+  ENABLED_BENCHMARK_MATMULT_INT_TRUE=
+  ENABLED_BENCHMARK_MATMULT_INT_FALSE='#'
+else
+  ENABLED_BENCHMARK_MATMULT_INT_TRUE='#'
+  ENABLED_BENCHMARK_MATMULT_INT_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-mergesort was given.
+if test "${enable_benchmark_mergesort+set}" = set; then :
+  enableval=$enable_benchmark_mergesort; case "${enableval}" in
+      yes) benchmark_mergesort=true ;;
+      no)  benchmark_mergesort=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-mergesort" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_mergesort = xtrue; then
+  ENABLED_BENCHMARK_MERGESORT_TRUE=
+  ENABLED_BENCHMARK_MERGESORT_FALSE='#'
+else
+  ENABLED_BENCHMARK_MERGESORT_TRUE='#'
+  ENABLED_BENCHMARK_MERGESORT_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-miniz was given.
+if test "${enable_benchmark_miniz+set}" = set; then :
+  enableval=$enable_benchmark_miniz; case "${enableval}" in
+      yes) benchmark_miniz=true ;;
+      no)  benchmark_miniz=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-miniz" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_miniz = xtrue; then
+  ENABLED_BENCHMARK_MINIZ_TRUE=
+  ENABLED_BENCHMARK_MINIZ_FALSE='#'
+else
+  ENABLED_BENCHMARK_MINIZ_TRUE='#'
+  ENABLED_BENCHMARK_MINIZ_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-minver was given.
+if test "${enable_benchmark_minver+set}" = set; then :
+  enableval=$enable_benchmark_minver; case "${enableval}" in
+      yes) benchmark_minver=true ;;
+      no)  benchmark_minver=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-minver" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_minver = xtrue; then
+  ENABLED_BENCHMARK_MINVER_TRUE=
+  ENABLED_BENCHMARK_MINVER_FALSE='#'
+else
+  ENABLED_BENCHMARK_MINVER_TRUE='#'
+  ENABLED_BENCHMARK_MINVER_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-nbody was given.
+if test "${enable_benchmark_nbody+set}" = set; then :
+  enableval=$enable_benchmark_nbody; case "${enableval}" in
+      yes) benchmark_nbody=true ;;
+      no)  benchmark_nbody=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-nbody" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_nbody = xtrue; then
+  ENABLED_BENCHMARK_NBODY_TRUE=
+  ENABLED_BENCHMARK_NBODY_FALSE='#'
+else
+  ENABLED_BENCHMARK_NBODY_TRUE='#'
+  ENABLED_BENCHMARK_NBODY_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-ndes was given.
+if test "${enable_benchmark_ndes+set}" = set; then :
+  enableval=$enable_benchmark_ndes; case "${enableval}" in
+      yes) benchmark_ndes=true ;;
+      no)  benchmark_ndes=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-ndes" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_ndes = xtrue; then
+  ENABLED_BENCHMARK_NDES_TRUE=
+  ENABLED_BENCHMARK_NDES_FALSE='#'
+else
+  ENABLED_BENCHMARK_NDES_TRUE='#'
+  ENABLED_BENCHMARK_NDES_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-nettle-arcfour was given.
+if test "${enable_benchmark_nettle_arcfour+set}" = set; then :
+  enableval=$enable_benchmark_nettle_arcfour; case "${enableval}" in
+      yes) benchmark_nettle_arcfour=true ;;
+      no)  benchmark_nettle_arcfour=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-nettle-arcfour" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_nettle_arcfour = xtrue; then
+  ENABLED_BENCHMARK_NETTLE_ARCFOUR_TRUE=
+  ENABLED_BENCHMARK_NETTLE_ARCFOUR_FALSE='#'
+else
+  ENABLED_BENCHMARK_NETTLE_ARCFOUR_TRUE='#'
+  ENABLED_BENCHMARK_NETTLE_ARCFOUR_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-nettle-cast128 was given.
+if test "${enable_benchmark_nettle_cast128+set}" = set; then :
+  enableval=$enable_benchmark_nettle_cast128; case "${enableval}" in
+      yes) benchmark_nettle_cast128=true ;;
+      no)  benchmark_nettle_cast128=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-nettle-cast128" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_nettle_cast128 = xtrue; then
+  ENABLED_BENCHMARK_NETTLE_CAST128_TRUE=
+  ENABLED_BENCHMARK_NETTLE_CAST128_FALSE='#'
+else
+  ENABLED_BENCHMARK_NETTLE_CAST128_TRUE='#'
+  ENABLED_BENCHMARK_NETTLE_CAST128_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-nettle-des was given.
+if test "${enable_benchmark_nettle_des+set}" = set; then :
+  enableval=$enable_benchmark_nettle_des; case "${enableval}" in
+      yes) benchmark_nettle_des=true ;;
+      no)  benchmark_nettle_des=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-nettle-des" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_nettle_des = xtrue; then
+  ENABLED_BENCHMARK_NETTLE_DES_TRUE=
+  ENABLED_BENCHMARK_NETTLE_DES_FALSE='#'
+else
+  ENABLED_BENCHMARK_NETTLE_DES_TRUE='#'
+  ENABLED_BENCHMARK_NETTLE_DES_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-nettle-md5 was given.
+if test "${enable_benchmark_nettle_md5+set}" = set; then :
+  enableval=$enable_benchmark_nettle_md5; case "${enableval}" in
+      yes) benchmark_nettle_md5=true ;;
+      no)  benchmark_nettle_md5=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-nettle-md5" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_nettle_md5 = xtrue; then
+  ENABLED_BENCHMARK_NETTLE_MD5_TRUE=
+  ENABLED_BENCHMARK_NETTLE_MD5_FALSE='#'
+else
+  ENABLED_BENCHMARK_NETTLE_MD5_TRUE='#'
+  ENABLED_BENCHMARK_NETTLE_MD5_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-nettle-sha256 was given.
+if test "${enable_benchmark_nettle_sha256+set}" = set; then :
+  enableval=$enable_benchmark_nettle_sha256; case "${enableval}" in
+      yes) benchmark_nettle_sha256=true ;;
+      no)  benchmark_nettle_sha256=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-nettle-sha256" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_nettle_sha256 = xtrue; then
+  ENABLED_BENCHMARK_NETTLE_SHA256_TRUE=
+  ENABLED_BENCHMARK_NETTLE_SHA256_FALSE='#'
+else
+  ENABLED_BENCHMARK_NETTLE_SHA256_TRUE='#'
+  ENABLED_BENCHMARK_NETTLE_SHA256_FALSE=
+fi
+
+
+
+# Check whether --enable-benchmark-newlib-exp was given.
+if test "${enable_benchmark_newlib_exp+set}" = set; then :
+  enableval=$enable_benchmark_newlib_exp; case "${enableval}" in
+      yes) benchmark_newlib_exp=true ;;
+      no)  benchmark_newlib_exp=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-newlib-exp" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_newlib_exp = xtrue; then
+  ENABLED_BENCHMARK_NEWLIB_EXP_TRUE=
+  ENABLED_BENCHMARK_NEWLIB_EXP_FALSE='#'
+else
+  ENABLED_BENCHMARK_NEWLIB_EXP_TRUE='#'
+  ENABLED_BENCHMARK_NEWLIB_EXP_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-newlib-log was given.
+if test "${enable_benchmark_newlib_log+set}" = set; then :
+  enableval=$enable_benchmark_newlib_log; case "${enableval}" in
+      yes) benchmark_newlib_log=true ;;
+      no)  benchmark_newlib_log=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-newlib-log" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_newlib_log = xtrue; then
+  ENABLED_BENCHMARK_NEWLIB_LOG_TRUE=
+  ENABLED_BENCHMARK_NEWLIB_LOG_FALSE='#'
+else
+  ENABLED_BENCHMARK_NEWLIB_LOG_TRUE='#'
+  ENABLED_BENCHMARK_NEWLIB_LOG_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-newlib-mod was given.
+if test "${enable_benchmark_newlib_mod+set}" = set; then :
+  enableval=$enable_benchmark_newlib_mod; case "${enableval}" in
+      yes) benchmark_newlib_mod=true ;;
+      no)  benchmark_newlib_mod=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-newlib-mod" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_newlib_mod = xtrue; then
+  ENABLED_BENCHMARK_NEWLIB_MOD_TRUE=
+  ENABLED_BENCHMARK_NEWLIB_MOD_FALSE='#'
+else
+  ENABLED_BENCHMARK_NEWLIB_MOD_TRUE='#'
+  ENABLED_BENCHMARK_NEWLIB_MOD_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-newlib-sqrt was given.
+if test "${enable_benchmark_newlib_sqrt+set}" = set; then :
+  enableval=$enable_benchmark_newlib_sqrt; case "${enableval}" in
+      yes) benchmark_newlib_sqrt=true ;;
+      no)  benchmark_newlib_sqrt=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-newlib-sqrt" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_newlib_sqrt = xtrue; then
+  ENABLED_BENCHMARK_NEWLIB_SQRT_TRUE=
+  ENABLED_BENCHMARK_NEWLIB_SQRT_FALSE='#'
+else
+  ENABLED_BENCHMARK_NEWLIB_SQRT_TRUE='#'
+  ENABLED_BENCHMARK_NEWLIB_SQRT_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-ns was given.
+if test "${enable_benchmark_ns+set}" = set; then :
+  enableval=$enable_benchmark_ns; case "${enableval}" in
+      yes) benchmark_ns=true ;;
+      no)  benchmark_ns=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-ns" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_ns = xtrue; then
+  ENABLED_BENCHMARK_NS_TRUE=
+  ENABLED_BENCHMARK_NS_FALSE='#'
+else
+  ENABLED_BENCHMARK_NS_TRUE='#'
+  ENABLED_BENCHMARK_NS_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-nsichneu was given.
+if test "${enable_benchmark_nsichneu+set}" = set; then :
+  enableval=$enable_benchmark_nsichneu; case "${enableval}" in
+      yes) benchmark_nsichneu=true ;;
+      no)  benchmark_nsichneu=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-nsichneu" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_nsichneu = xtrue; then
+  ENABLED_BENCHMARK_NSICHNEU_TRUE=
+  ENABLED_BENCHMARK_NSICHNEU_FALSE='#'
+else
+  ENABLED_BENCHMARK_NSICHNEU_TRUE='#'
+  ENABLED_BENCHMARK_NSICHNEU_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-picojpeg was given.
+if test "${enable_benchmark_picojpeg+set}" = set; then :
+  enableval=$enable_benchmark_picojpeg; case "${enableval}" in
+      yes) benchmark_picojpeg=true ;;
+      no)  benchmark_picojpeg=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-picojpeg" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_picojpeg = xtrue; then
+  ENABLED_BENCHMARK_PICOJPEG_TRUE=
+  ENABLED_BENCHMARK_PICOJPEG_FALSE='#'
+else
+  ENABLED_BENCHMARK_PICOJPEG_TRUE='#'
+  ENABLED_BENCHMARK_PICOJPEG_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-prime was given.
+if test "${enable_benchmark_prime+set}" = set; then :
+  enableval=$enable_benchmark_prime; case "${enableval}" in
+      yes) benchmark_prime=true ;;
+      no)  benchmark_prime=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-prime" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_prime = xtrue; then
+  ENABLED_BENCHMARK_PRIME_TRUE=
+  ENABLED_BENCHMARK_PRIME_FALSE='#'
+else
+  ENABLED_BENCHMARK_PRIME_TRUE='#'
+  ENABLED_BENCHMARK_PRIME_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-qrduino was given.
+if test "${enable_benchmark_qrduino+set}" = set; then :
+  enableval=$enable_benchmark_qrduino; case "${enableval}" in
+      yes) benchmark_qrduino=true ;;
+      no)  benchmark_qrduino=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-qrduino" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_qrduino = xtrue; then
+  ENABLED_BENCHMARK_QRDUINO_TRUE=
+  ENABLED_BENCHMARK_QRDUINO_FALSE='#'
+else
+  ENABLED_BENCHMARK_QRDUINO_TRUE='#'
+  ENABLED_BENCHMARK_QRDUINO_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-qsort was given.
+if test "${enable_benchmark_qsort+set}" = set; then :
+  enableval=$enable_benchmark_qsort; case "${enableval}" in
+      yes) benchmark_qsort=true ;;
+      no)  benchmark_qsort=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-qsort" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_qsort = xtrue; then
+  ENABLED_BENCHMARK_QSORT_TRUE=
+  ENABLED_BENCHMARK_QSORT_FALSE='#'
+else
+  ENABLED_BENCHMARK_QSORT_TRUE='#'
+  ENABLED_BENCHMARK_QSORT_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-qurt was given.
+if test "${enable_benchmark_qurt+set}" = set; then :
+  enableval=$enable_benchmark_qurt; case "${enableval}" in
+      yes) benchmark_qurt=true ;;
+      no)  benchmark_qurt=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-qurt" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_qurt = xtrue; then
+  ENABLED_BENCHMARK_QURT_TRUE=
+  ENABLED_BENCHMARK_QURT_FALSE='#'
+else
+  ENABLED_BENCHMARK_QURT_TRUE='#'
+  ENABLED_BENCHMARK_QURT_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-recursion was given.
+if test "${enable_benchmark_recursion+set}" = set; then :
+  enableval=$enable_benchmark_recursion; case "${enableval}" in
+      yes) benchmark_recursion=true ;;
+      no)  benchmark_recursion=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-recursion" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_recursion = xtrue; then
+  ENABLED_BENCHMARK_RECURSION_TRUE=
+  ENABLED_BENCHMARK_RECURSION_FALSE='#'
+else
+  ENABLED_BENCHMARK_RECURSION_TRUE='#'
+  ENABLED_BENCHMARK_RECURSION_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-rijndael was given.
+if test "${enable_benchmark_rijndael+set}" = set; then :
+  enableval=$enable_benchmark_rijndael; case "${enableval}" in
+      yes) benchmark_rijndael=true ;;
+      no)  benchmark_rijndael=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-rijndael" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_rijndael = xtrue; then
+  ENABLED_BENCHMARK_RIJNDAEL_TRUE=
+  ENABLED_BENCHMARK_RIJNDAEL_FALSE='#'
+else
+  ENABLED_BENCHMARK_RIJNDAEL_TRUE='#'
+  ENABLED_BENCHMARK_RIJNDAEL_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-select was given.
+if test "${enable_benchmark_select+set}" = set; then :
+  enableval=$enable_benchmark_select; case "${enableval}" in
+      yes) benchmark_select=true ;;
+      no)  benchmark_select=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-select" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_select = xtrue; then
+  ENABLED_BENCHMARK_SELECT_TRUE=
+  ENABLED_BENCHMARK_SELECT_FALSE='#'
+else
+  ENABLED_BENCHMARK_SELECT_TRUE='#'
+  ENABLED_BENCHMARK_SELECT_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-sglib-arraybinsearch was given.
+if test "${enable_benchmark_sglib_arraybinsearch+set}" = set; then :
+  enableval=$enable_benchmark_sglib_arraybinsearch; case "${enableval}" in
+      yes) benchmark_sglib_arraybinsearch=true ;;
+      no)  benchmark_sglib_arraybinsearch=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-sglib-arraybinsearch" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_sglib_arraybinsearch = xtrue; then
+  ENABLED_BENCHMARK_SGLIB_ARRAYBINSEARCH_TRUE=
+  ENABLED_BENCHMARK_SGLIB_ARRAYBINSEARCH_FALSE='#'
+else
+  ENABLED_BENCHMARK_SGLIB_ARRAYBINSEARCH_TRUE='#'
+  ENABLED_BENCHMARK_SGLIB_ARRAYBINSEARCH_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-sglib-arrayheapsort was given.
+if test "${enable_benchmark_sglib_arrayheapsort+set}" = set; then :
+  enableval=$enable_benchmark_sglib_arrayheapsort; case "${enableval}" in
+      yes) benchmark_sglib_arrayheapsort=true ;;
+      no)  benchmark_sglib_arrayheapsort=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-sglib-arrayheapsort" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_sglib_arrayheapsort = xtrue; then
+  ENABLED_BENCHMARK_SGLIB_ARRAYHEAPSORT_TRUE=
+  ENABLED_BENCHMARK_SGLIB_ARRAYHEAPSORT_FALSE='#'
+else
+  ENABLED_BENCHMARK_SGLIB_ARRAYHEAPSORT_TRUE='#'
+  ENABLED_BENCHMARK_SGLIB_ARRAYHEAPSORT_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-sglib-arrayquicksort was given.
+if test "${enable_benchmark_sglib_arrayquicksort+set}" = set; then :
+  enableval=$enable_benchmark_sglib_arrayquicksort; case "${enableval}" in
+      yes) benchmark_sglib_arrayquicksort=true ;;
+      no)  benchmark_sglib_arrayquicksort=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-sglib-arrayquicksort" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_sglib_arrayquicksort = xtrue; then
+  ENABLED_BENCHMARK_SGLIB_ARRAYQUICKSORT_TRUE=
+  ENABLED_BENCHMARK_SGLIB_ARRAYQUICKSORT_FALSE='#'
+else
+  ENABLED_BENCHMARK_SGLIB_ARRAYQUICKSORT_TRUE='#'
+  ENABLED_BENCHMARK_SGLIB_ARRAYQUICKSORT_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-sglib-dllist was given.
+if test "${enable_benchmark_sglib_dllist+set}" = set; then :
+  enableval=$enable_benchmark_sglib_dllist; case "${enableval}" in
+      yes) benchmark_sglib_dllist=true ;;
+      no)  benchmark_sglib_dllist=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-sglib-dllist" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_sglib_dllist = xtrue; then
+  ENABLED_BENCHMARK_SGLIB_DLLIST_TRUE=
+  ENABLED_BENCHMARK_SGLIB_DLLIST_FALSE='#'
+else
+  ENABLED_BENCHMARK_SGLIB_DLLIST_TRUE='#'
+  ENABLED_BENCHMARK_SGLIB_DLLIST_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-sglib-hashtable was given.
+if test "${enable_benchmark_sglib_hashtable+set}" = set; then :
+  enableval=$enable_benchmark_sglib_hashtable; case "${enableval}" in
+      yes) benchmark_sglib_hashtable=true ;;
+      no)  benchmark_sglib_hashtable=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-sglib-hashtable" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_sglib_hashtable = xtrue; then
+  ENABLED_BENCHMARK_SGLIB_HASHTABLE_TRUE=
+  ENABLED_BENCHMARK_SGLIB_HASHTABLE_FALSE='#'
+else
+  ENABLED_BENCHMARK_SGLIB_HASHTABLE_TRUE='#'
+  ENABLED_BENCHMARK_SGLIB_HASHTABLE_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-sglib-listinsertsort was given.
+if test "${enable_benchmark_sglib_listinsertsort+set}" = set; then :
+  enableval=$enable_benchmark_sglib_listinsertsort; case "${enableval}" in
+      yes) benchmark_sglib_listinsertsort=true ;;
+      no)  benchmark_sglib_listinsertsort=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-sglib-listinsertsort" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_sglib_listinsertsort = xtrue; then
+  ENABLED_BENCHMARK_SGLIB_LISTINSERTSORT_TRUE=
+  ENABLED_BENCHMARK_SGLIB_LISTINSERTSORT_FALSE='#'
+else
+  ENABLED_BENCHMARK_SGLIB_LISTINSERTSORT_TRUE='#'
+  ENABLED_BENCHMARK_SGLIB_LISTINSERTSORT_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-sglib-listsort was given.
+if test "${enable_benchmark_sglib_listsort+set}" = set; then :
+  enableval=$enable_benchmark_sglib_listsort; case "${enableval}" in
+      yes) benchmark_sglib_listsort=true ;;
+      no)  benchmark_sglib_listsort=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-sglib-listsort" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_sglib_listsort = xtrue; then
+  ENABLED_BENCHMARK_SGLIB_LISTSORT_TRUE=
+  ENABLED_BENCHMARK_SGLIB_LISTSORT_FALSE='#'
+else
+  ENABLED_BENCHMARK_SGLIB_LISTSORT_TRUE='#'
+  ENABLED_BENCHMARK_SGLIB_LISTSORT_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-sglib-queue was given.
+if test "${enable_benchmark_sglib_queue+set}" = set; then :
+  enableval=$enable_benchmark_sglib_queue; case "${enableval}" in
+      yes) benchmark_sglib_queue=true ;;
+      no)  benchmark_sglib_queue=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-sglib-queue" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_sglib_queue = xtrue; then
+  ENABLED_BENCHMARK_SGLIB_QUEUE_TRUE=
+  ENABLED_BENCHMARK_SGLIB_QUEUE_FALSE='#'
+else
+  ENABLED_BENCHMARK_SGLIB_QUEUE_TRUE='#'
+  ENABLED_BENCHMARK_SGLIB_QUEUE_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-sglib-rbtree was given.
+if test "${enable_benchmark_sglib_rbtree+set}" = set; then :
+  enableval=$enable_benchmark_sglib_rbtree; case "${enableval}" in
+      yes) benchmark_sglib_rbtree=true ;;
+      no)  benchmark_sglib_rbtree=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-sglib-rbtree" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_sglib_rbtree = xtrue; then
+  ENABLED_BENCHMARK_SGLIB_RBTREE_TRUE=
+  ENABLED_BENCHMARK_SGLIB_RBTREE_FALSE='#'
+else
+  ENABLED_BENCHMARK_SGLIB_RBTREE_TRUE='#'
+  ENABLED_BENCHMARK_SGLIB_RBTREE_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-slre was given.
+if test "${enable_benchmark_slre+set}" = set; then :
+  enableval=$enable_benchmark_slre; case "${enableval}" in
+      yes) benchmark_slre=true ;;
+      no)  benchmark_slre=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-slre" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_slre = xtrue; then
+  ENABLED_BENCHMARK_SLRE_TRUE=
+  ENABLED_BENCHMARK_SLRE_FALSE='#'
+else
+  ENABLED_BENCHMARK_SLRE_TRUE='#'
+  ENABLED_BENCHMARK_SLRE_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-sqrt was given.
+if test "${enable_benchmark_sqrt+set}" = set; then :
+  enableval=$enable_benchmark_sqrt; case "${enableval}" in
+      yes) benchmark_sqrt=true ;;
+      no)  benchmark_sqrt=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-sqrt" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_sqrt = xtrue; then
+  ENABLED_BENCHMARK_SQRT_TRUE=
+  ENABLED_BENCHMARK_SQRT_FALSE='#'
+else
+  ENABLED_BENCHMARK_SQRT_TRUE='#'
+  ENABLED_BENCHMARK_SQRT_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-st was given.
+if test "${enable_benchmark_st+set}" = set; then :
+  enableval=$enable_benchmark_st; case "${enableval}" in
+      yes) benchmark_st=true ;;
+      no)  benchmark_st=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-st" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_st = xtrue; then
+  ENABLED_BENCHMARK_ST_TRUE=
+  ENABLED_BENCHMARK_ST_FALSE='#'
+else
+  ENABLED_BENCHMARK_ST_TRUE='#'
+  ENABLED_BENCHMARK_ST_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-statemate was given.
+if test "${enable_benchmark_statemate+set}" = set; then :
+  enableval=$enable_benchmark_statemate; case "${enableval}" in
+      yes) benchmark_statemate=true ;;
+      no)  benchmark_statemate=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-statemate" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_statemate = xtrue; then
+  ENABLED_BENCHMARK_STATEMATE_TRUE=
+  ENABLED_BENCHMARK_STATEMATE_FALSE='#'
+else
+  ENABLED_BENCHMARK_STATEMATE_TRUE='#'
+  ENABLED_BENCHMARK_STATEMATE_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-stb_perlin was given.
+if test "${enable_benchmark_stb_perlin+set}" = set; then :
+  enableval=$enable_benchmark_stb_perlin; case "${enableval}" in
+      yes) benchmark_stb_perlin=true ;;
+      no)  benchmark_stb_perlin=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-stb_perlin" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_stb_perlin = xtrue; then
+  ENABLED_BENCHMARK_STB_PERLIN_TRUE=
+  ENABLED_BENCHMARK_STB_PERLIN_FALSE='#'
+else
+  ENABLED_BENCHMARK_STB_PERLIN_TRUE='#'
+  ENABLED_BENCHMARK_STB_PERLIN_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-stringsearch1 was given.
+if test "${enable_benchmark_stringsearch1+set}" = set; then :
+  enableval=$enable_benchmark_stringsearch1; case "${enableval}" in
+      yes) benchmark_stringsearch1=true ;;
+      no)  benchmark_stringsearch1=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-stringsearch1" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_stringsearch1 = xtrue; then
+  ENABLED_BENCHMARK_STRINGSEARCH1_TRUE=
+  ENABLED_BENCHMARK_STRINGSEARCH1_FALSE='#'
+else
+  ENABLED_BENCHMARK_STRINGSEARCH1_TRUE='#'
+  ENABLED_BENCHMARK_STRINGSEARCH1_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-strstr was given.
+if test "${enable_benchmark_strstr+set}" = set; then :
+  enableval=$enable_benchmark_strstr; case "${enableval}" in
+      yes) benchmark_strstr=true ;;
+      no)  benchmark_strstr=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-strstr" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_strstr = xtrue; then
+  ENABLED_BENCHMARK_STRSTR_TRUE=
+  ENABLED_BENCHMARK_STRSTR_FALSE='#'
+else
+  ENABLED_BENCHMARK_STRSTR_TRUE='#'
+  ENABLED_BENCHMARK_STRSTR_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-tarai was given.
+if test "${enable_benchmark_tarai+set}" = set; then :
+  enableval=$enable_benchmark_tarai; case "${enableval}" in
+      yes) benchmark_tarai=true ;;
+      no)  benchmark_tarai=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-tarai" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_tarai = xtrue; then
+  ENABLED_BENCHMARK_TARAI_TRUE=
+  ENABLED_BENCHMARK_TARAI_FALSE='#'
+else
+  ENABLED_BENCHMARK_TARAI_TRUE='#'
+  ENABLED_BENCHMARK_TARAI_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-template was given.
+if test "${enable_benchmark_template+set}" = set; then :
+  enableval=$enable_benchmark_template; case "${enableval}" in
+      yes) benchmark_template=true ;;
+      no)  benchmark_template=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-template" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_template = xtrue; then
+  ENABLED_BENCHMARK_TEMPLATE_TRUE=
+  ENABLED_BENCHMARK_TEMPLATE_FALSE='#'
+else
+  ENABLED_BENCHMARK_TEMPLATE_TRUE='#'
+  ENABLED_BENCHMARK_TEMPLATE_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-trio-snprintf was given.
+if test "${enable_benchmark_trio_snprintf+set}" = set; then :
+  enableval=$enable_benchmark_trio_snprintf; case "${enableval}" in
+      yes) benchmark_trio_snprintf=true ;;
+      no)  benchmark_trio_snprintf=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-trio-snprintf" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_trio_snprintf = xtrue; then
+  ENABLED_BENCHMARK_TRIO_SNPRINTF_TRUE=
+  ENABLED_BENCHMARK_TRIO_SNPRINTF_FALSE='#'
+else
+  ENABLED_BENCHMARK_TRIO_SNPRINTF_TRUE='#'
+  ENABLED_BENCHMARK_TRIO_SNPRINTF_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-trio-sscanf was given.
+if test "${enable_benchmark_trio_sscanf+set}" = set; then :
+  enableval=$enable_benchmark_trio_sscanf; case "${enableval}" in
+      yes) benchmark_trio_sscanf=true ;;
+      no)  benchmark_trio_sscanf=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-trio-sscanf" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_trio_sscanf = xtrue; then
+  ENABLED_BENCHMARK_TRIO_SSCANF_TRUE=
+  ENABLED_BENCHMARK_TRIO_SSCANF_FALSE='#'
+else
+  ENABLED_BENCHMARK_TRIO_SSCANF_TRUE='#'
+  ENABLED_BENCHMARK_TRIO_SSCANF_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-ud was given.
+if test "${enable_benchmark_ud+set}" = set; then :
+  enableval=$enable_benchmark_ud; case "${enableval}" in
+      yes) benchmark_ud=true ;;
+      no)  benchmark_ud=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-ud" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_ud = xtrue; then
+  ENABLED_BENCHMARK_UD_TRUE=
+  ENABLED_BENCHMARK_UD_FALSE='#'
+else
+  ENABLED_BENCHMARK_UD_TRUE='#'
+  ENABLED_BENCHMARK_UD_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-whetstone was given.
+if test "${enable_benchmark_whetstone+set}" = set; then :
+  enableval=$enable_benchmark_whetstone; case "${enableval}" in
+      yes) benchmark_whetstone=true ;;
+      no)  benchmark_whetstone=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-whetstone" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_whetstone = xtrue; then
+  ENABLED_BENCHMARK_WHETSTONE_TRUE=
+  ENABLED_BENCHMARK_WHETSTONE_FALSE='#'
+else
+  ENABLED_BENCHMARK_WHETSTONE_TRUE='#'
+  ENABLED_BENCHMARK_WHETSTONE_FALSE=
+fi
+
+
+# Check whether --enable-benchmark-wikisort was given.
+if test "${enable_benchmark_wikisort+set}" = set; then :
+  enableval=$enable_benchmark_wikisort; case "${enableval}" in
+      yes) benchmark_wikisort=true ;;
+      no)  benchmark_wikisort=false ;;
+      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-wikisort" "$LINENO" 5 ;;
+   esac
+fi
+
+ if test x$benchmark_wikisort = xtrue; then
+  ENABLED_BENCHMARK_WIKISORT_TRUE=
+  ENABLED_BENCHMARK_WIKISORT_FALSE='#'
+else
+  ENABLED_BENCHMARK_WIKISORT_TRUE='#'
+  ENABLED_BENCHMARK_WIKISORT_FALSE=
+fi
+
+
+
+# What to set DUMMY_* to if the dummy libraries are enabled.
+
+DUMMY_CRT0_YES="\$(top_builddir)/support/libdummycrt0.la"
+DUMMY_LIBGCC_YES="\$(top_builddir)/support/libdummygcc.la"
+DUMMY_COMPILERRT_YES="\$(top_builddir)/support/libdummycompilerrt.la"
+DUMMY_LIBC_YES="-Wl,--start-group \$(top_builddir)/support/libdummyc.la"
+DUMMY_LIBM_YES="\$(top_builddir)/support/libdummym.la"
+
+# Enable dummy libraries
+
+case "${USE_DUMMY_CRT0}" in
+   yes) DUMMY_CRT0=${DUMMY_CRT0_YES} ;;
+   no)  DUMMY_CRT0= ;;
+   *)   DUMMY_CRT0=${USE_DUMMY_CRT0} ;;
+esac
+
+case "${USE_DUMMY_LIBGCC}" in
+   yes) DUMMY_LIBGCC=${DUMMY_LIBGCC_YES} ;;
+   no)  DUMMY_LIBGCC= ;;
+   *)   DUMMY_LIBGCC=${USE_DUMMY_LIBGCC} ;;
+esac
+
+case "${USE_DUMMY_COMPILERRT}" in
+   yes) DUMMY_COMPILERRT=${DUMMY_COMPILERRT_YES} ;;
+   no)  DUMMY_COMPILERRT= ;;
+   *)   DUMMY_COMPILERRT=${USE_DUMMY_COMPILERRT} ;;
+esac
+
+case "${USE_DUMMY_LIBC}" in
+   yes) DUMMY_LIBC=${DUMMY_LIBC_YES} ;;
+   no)  DUMMY_LIBC= ;;
+   *)   DUMMY_LIBC=${USE_DUMMY_LIBC} ;;
+esac
+
+case "${USE_DUMMY_LIBM}" in
+   yes) DUMMY_LIBM=${DUMMY_LIBM_YES} ;;
+   no)  DUMMY_LIBM="-lm" ;;
+   *)   DUMMY_LIBM=${USE_DUMMY_LIBM} ;;
+esac
+
+# Check for support code
+
+ if test -f $srcdir/config/$arch/chips/$chip/chipsupport.c; then
+  CHIPSUPPORT_C_TRUE=
+  CHIPSUPPORT_C_FALSE='#'
+else
+  CHIPSUPPORT_C_TRUE='#'
+  CHIPSUPPORT_C_FALSE=
+fi
+
+
+# Check for support headers
+
+test -f $srcdir/config/$arch/boards/$board/boardsupport.h && \
+
+$as_echo "#define HAVE_BOARDSUPPORT_H 1" >>confdefs.h
+
+
+test -f $srcdir/config/$arch/chips/$chip/chipsupport.h && \
+
+$as_echo "#define HAVE_CHIPSUPPORT_H 1" >>confdefs.h
+
+
+# Test whether we have a calibration file
+
+test -f $srcdir/config/$arch/boards/$board/calibration && \
+    HAVE_CALIBRATION=yes && \
+
+$as_echo "#define HAVE_CALIBRATION 1" >>confdefs.h
+
+
+ if test x$HAVE_CALIBRATION == xyes; then
+  CALIBRATION_TRUE=
+  CALIBRATION_FALSE='#'
+else
+  CALIBRATION_TRUE='#'
+  CALIBRATION_FALSE=
+fi
+
+
+# Architecture, board and chip specific CFLAGS and LDFLAGS
+CFLAGS="$CFLAGS $ARCH_CFLAGS $CHIP_CFLAGS $BOARD_CFLAGS"
+LDFLAGS="$LDFLAGS $ARCH_LDFLAGS $CHIP_LDFLAGS $BOARD_LDFLAGS"
 
 case `pwd` in
   *\ * | *\	*)
@@ -12370,1784 +14147,6 @@ CC=$lt_save_CC
 
 
 
-# List of all benchmarks
-
-bmlist="aha-compress          \
-        aha-mont64            \
-        bs                    \
-        bubblesort            \
-        cnt                   \
-        compress              \
-        cover                 \
-        crc                   \
-        crc32                 \
-        ctl                   \
-        ctl-stack             \
-        ctl-string            \
-        ctl-vector            \
-        cubic                 \
-        dijkstra              \
-        dtoa                  \
-        duff                  \
-        edn                   \
-        expint                \
-        fac                   \
-        fasta                 \
-        fdct                  \
-        fibcall               \
-        fir                   \
-        frac                  \
-        huffbench             \
-        insertsort            \
-        janne_complex         \
-        jfdctint              \
-        lcdnum                \
-        levenshtein           \
-        ludcmp                \
-        matmult               \
-        matmult-float         \
-        matmult-int           \
-        mergesort             \
-        miniz                 \
-        minver                \
-        nbody                 \
-        ndes                  \
-        nettle-arcfour        \
-        nettle-cast128        \
-        nettle-des            \
-        nettle-md5            \
-        nettle-sha256         \
-        newlib-exp            \
-        newlib-log            \
-        newlib-mod            \
-        newlib-sqrt           \
-        ns                    \
-        nsichneu              \
-        picojpeg              \
-        prime                 \
-        qrduino               \
-        qsort                 \
-        qurt                  \
-        recursion             \
-        rijndael              \
-        select                \
-        sglib-arraybinsearch  \
-        sglib-arrayheapsort   \
-        sglib-arrayquicksort  \
-        sglib-arraysort       \
-        sglib-dllist          \
-        sglib-hashtable       \
-        sglib-listinsertsort  \
-        sglib-listsort        \
-        sglib-queue           \
-        sglib-rbtree          \
-        slre                  \
-        sqrt                  \
-        st                    \
-        statemate             \
-        stb_perlin            \
-        stringsearch1         \
-        strstr                \
-        tarai                 \
-        template              \
-        trio                  \
-        trio-snprintf         \
-        trio-sscanf           \
-        ud                    \
-        whetstone             \
-        wikisort"
-
-# Set default values enabling all architectures
-
-benchmark_aha_compress=true
-benchmark_aha_mont64=true
-benchmark_bs=true
-benchmark_bubblesort=true
-benchmark_cnt=true
-benchmark_compress=true
-benchmark_cover=true
-benchmark_crc=true
-benchmark_crc32=true
-benchmark_ctl_stack=true
-benchmark_ctl_string=true
-benchmark_ctl_vector=true
-benchmark_cubic=true
-benchmark_dijkstra=true
-benchmark_dtoa=true
-benchmark_duff=true
-benchmark_edn=true
-benchmark_expint=true
-benchmark_fac=true
-benchmark_fasta=true
-benchmark_fdct=true
-benchmark_fibcall=true
-benchmark_fir=true
-benchmark_frac=true
-benchmark_huffbench=true
-benchmark_insertsort=true
-benchmark_janne_complex=true
-benchmark_jfdctint=true
-benchmark_lcdnum=true
-benchmark_levenshtein=true
-benchmark_ludcmp=true
-benchmark_matmult_float=true
-benchmark_matmult_int=true
-benchmark_mergesort=true
-benchmark_miniz=true
-benchmark_minver=true
-benchmark_nbody=true
-benchmark_ndes=true
-benchmark_nettle_arcfour=true
-benchmark_nettle_cast128=true
-benchmark_nettle_des=true
-benchmark_nettle_md5=true
-benchmark_nettle_sha256=true
-benchmark_newlib_exp=true
-benchmark_newlib_log=true
-benchmark_newlib_mod=true
-benchmark_newlib_sqrt=true
-benchmark_ns=true
-benchmark_nsichneu=true
-benchmark_picojpeg=true
-benchmark_prime=true
-benchmark_qrduino=true
-benchmark_qsort=true
-benchmark_qurt=true
-benchmark_recursion=true
-benchmark_rijndael=true
-benchmark_select=true
-benchmark_sglib_arraybinsearch=true
-benchmark_sglib_arrayheapsort=true
-benchmark_sglib_arrayquicksort=true
-benchmark_sglib_dllist=true
-benchmark_sglib_hashtable=true
-benchmark_sglib_listinsertsort=true
-benchmark_sglib_listsort=true
-benchmark_sglib_queue=true
-benchmark_sglib_rbtree=true
-benchmark_slre=true
-benchmark_sqrt=true
-benchmark_st=true
-benchmark_statemate=true
-benchmark_stb_perlin=true
-benchmark_stringsearch1=true
-benchmark_strstr=true
-benchmark_tarai=true
-benchmark_template=true
-benchmark_trio_snprintf=true
-benchmark_trio_sscanf=true
-benchmark_ud=true
-benchmark_whetstone=true
-benchmark_wikisort=true
-
-# Work out which architecture we are targeting
-# Also pass this through to be substituted
-
-arch=$host_cpu
-
-# Option for selecting the target board
-
-
-# Check whether --with-board was given.
-if test "${with_board+set}" = set; then :
-  withval=$with_board; board=$with_board
-else
-  board=none
-fi
-
-
-# Option for selecting the target chip
-
-
-# Check whether --with-chip was given.
-if test "${with_chip+set}" = set; then :
-  withval=$with_chip; chip=$with_chip
-else
-  chip=generic
-fi
-
-
-# Default settings for dummy libraries. These can be overridden by the
-# chip configuration or configure flags. We default to having them all
-# off because we expect the default setup to produce compiled code that
-# can actually be executed - however, the dummy libraries are helpful
-# for analysing code size without library code inclusion confounding
-# things.
-
-USE_DUMMY_CRT0=no
-USE_DUMMY_LIBGCC=no
-USE_DUMMY_COMPILERRT=no
-USE_DUMMY_LIBC=no
-USE_DUMMY_LIBM=no
-
-# Execute any architecture, board or chip specific configuration. These can
-# set architecture, chip and board CPPFLAGS, CFLAGS and LDFLAGS and exclude
-# individual tests by setting benchmark_<bm> to false.
-
-# We can't use AC_CHECK_FILE, because we are cross-compiling, and that
-# prohibits use of AC_CHECK_FILE.
-
-if test -f $srcdir/config/$arch/arch.cfg; then :
-  source $srcdir/config/$arch/arch.cfg
-fi
-
-if test -d $srcdir/config/$arch/chips/$chip; then :
-
-else
-  as_fn_error $? "Chip config directory \"$chip\" does not exist" "$LINENO" 5
-fi
-
-if test -f $srcdir/config/$arch/chips/$chip/chip.cfg; then :
-  source $srcdir/config/$arch/chips/$chip/chip.cfg
-fi
-
-if test -d $srcdir/config/$arch/boards/$board; then :
-
-else
-  as_fn_error $? "Board config directory \"$board\" does not exist" "$LINENO" 5
-fi
-
-if test -f $srcdir/config/$arch/boards/$board/board.cfg ; then :
-  source $srcdir/config/$arch/boards/$board/board.cfg
-fi
-
-# Options for enabling/disabling each test in alphabetical order (see
-# genmacros.sh for a script to generate all of this). To add one new test just
-# insert the same pattern at the correct place in the list.
-
-# Remember that ctl, matmult, sglib-arraysort and trio are not benchmarks
-# themselves, but the frameworks from which others are created.
-
-# NOTE. There is the m4_foreach macro, but getting it to work for this seems to
-# be impossible
-
-# Check whether --enable-benchmark-aha-compress was given.
-if test "${enable_benchmark_aha_compress+set}" = set; then :
-  enableval=$enable_benchmark_aha_compress; case "${enableval}" in
-      yes) benchmark_aha_compress=true ;;
-      no)  benchmark_aha_compress=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-aha-compress" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_aha_compress = xtrue; then
-  ENABLED_BENCHMARK_AHA_COMPRESS_TRUE=
-  ENABLED_BENCHMARK_AHA_COMPRESS_FALSE='#'
-else
-  ENABLED_BENCHMARK_AHA_COMPRESS_TRUE='#'
-  ENABLED_BENCHMARK_AHA_COMPRESS_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-aha-mont64 was given.
-if test "${enable_benchmark_aha_mont64+set}" = set; then :
-  enableval=$enable_benchmark_aha_mont64; case "${enableval}" in
-      yes) benchmark_aha_mont64=true ;;
-      no)  benchmark_aha_mont64=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-aha-mont64" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_aha_mont64 = xtrue; then
-  ENABLED_BENCHMARK_AHA_MONT64_TRUE=
-  ENABLED_BENCHMARK_AHA_MONT64_FALSE='#'
-else
-  ENABLED_BENCHMARK_AHA_MONT64_TRUE='#'
-  ENABLED_BENCHMARK_AHA_MONT64_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-bs was given.
-if test "${enable_benchmark_bs+set}" = set; then :
-  enableval=$enable_benchmark_bs; case "${enableval}" in
-      yes) benchmark_bs=true ;;
-      no)  benchmark_bs=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-bs" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_bs = xtrue; then
-  ENABLED_BENCHMARK_BS_TRUE=
-  ENABLED_BENCHMARK_BS_FALSE='#'
-else
-  ENABLED_BENCHMARK_BS_TRUE='#'
-  ENABLED_BENCHMARK_BS_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-bubblesort was given.
-if test "${enable_benchmark_bubblesort+set}" = set; then :
-  enableval=$enable_benchmark_bubblesort; case "${enableval}" in
-      yes) benchmark_bubblesort=true ;;
-      no)  benchmark_bubblesort=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-bubblesort" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_bubblesort = xtrue; then
-  ENABLED_BENCHMARK_BUBBLESORT_TRUE=
-  ENABLED_BENCHMARK_BUBBLESORT_FALSE='#'
-else
-  ENABLED_BENCHMARK_BUBBLESORT_TRUE='#'
-  ENABLED_BENCHMARK_BUBBLESORT_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-cnt was given.
-if test "${enable_benchmark_cnt+set}" = set; then :
-  enableval=$enable_benchmark_cnt; case "${enableval}" in
-      yes) benchmark_cnt=true ;;
-      no)  benchmark_cnt=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-cnt" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_cnt = xtrue; then
-  ENABLED_BENCHMARK_CNT_TRUE=
-  ENABLED_BENCHMARK_CNT_FALSE='#'
-else
-  ENABLED_BENCHMARK_CNT_TRUE='#'
-  ENABLED_BENCHMARK_CNT_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-compress was given.
-if test "${enable_benchmark_compress+set}" = set; then :
-  enableval=$enable_benchmark_compress; case "${enableval}" in
-      yes) benchmark_compress=true ;;
-      no)  benchmark_compress=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-compress" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_compress = xtrue; then
-  ENABLED_BENCHMARK_COMPRESS_TRUE=
-  ENABLED_BENCHMARK_COMPRESS_FALSE='#'
-else
-  ENABLED_BENCHMARK_COMPRESS_TRUE='#'
-  ENABLED_BENCHMARK_COMPRESS_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-cover was given.
-if test "${enable_benchmark_cover+set}" = set; then :
-  enableval=$enable_benchmark_cover; case "${enableval}" in
-      yes) benchmark_cover=true ;;
-      no)  benchmark_cover=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-cover" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_cover = xtrue; then
-  ENABLED_BENCHMARK_COVER_TRUE=
-  ENABLED_BENCHMARK_COVER_FALSE='#'
-else
-  ENABLED_BENCHMARK_COVER_TRUE='#'
-  ENABLED_BENCHMARK_COVER_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-crc was given.
-if test "${enable_benchmark_crc+set}" = set; then :
-  enableval=$enable_benchmark_crc; case "${enableval}" in
-      yes) benchmark_crc=true ;;
-      no)  benchmark_crc=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-crc" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_crc = xtrue; then
-  ENABLED_BENCHMARK_CRC_TRUE=
-  ENABLED_BENCHMARK_CRC_FALSE='#'
-else
-  ENABLED_BENCHMARK_CRC_TRUE='#'
-  ENABLED_BENCHMARK_CRC_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-crc32 was given.
-if test "${enable_benchmark_crc32+set}" = set; then :
-  enableval=$enable_benchmark_crc32; case "${enableval}" in
-      yes) benchmark_crc32=true ;;
-      no)  benchmark_crc32=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-crc32" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_crc32 = xtrue; then
-  ENABLED_BENCHMARK_CRC32_TRUE=
-  ENABLED_BENCHMARK_CRC32_FALSE='#'
-else
-  ENABLED_BENCHMARK_CRC32_TRUE='#'
-  ENABLED_BENCHMARK_CRC32_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-ctl-stack was given.
-if test "${enable_benchmark_ctl_stack+set}" = set; then :
-  enableval=$enable_benchmark_ctl_stack; case "${enableval}" in
-      yes) benchmark_ctl_stack=true ;;
-      no)  benchmark_ctl_stack=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-ctl-stack" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_ctl_stack = xtrue; then
-  ENABLED_BENCHMARK_CTL_STACK_TRUE=
-  ENABLED_BENCHMARK_CTL_STACK_FALSE='#'
-else
-  ENABLED_BENCHMARK_CTL_STACK_TRUE='#'
-  ENABLED_BENCHMARK_CTL_STACK_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-ctl-string was given.
-if test "${enable_benchmark_ctl_string+set}" = set; then :
-  enableval=$enable_benchmark_ctl_string; case "${enableval}" in
-      yes) benchmark_ctl_string=true ;;
-      no)  benchmark_ctl_string=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-ctl-string" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_ctl_string = xtrue; then
-  ENABLED_BENCHMARK_CTL_STRING_TRUE=
-  ENABLED_BENCHMARK_CTL_STRING_FALSE='#'
-else
-  ENABLED_BENCHMARK_CTL_STRING_TRUE='#'
-  ENABLED_BENCHMARK_CTL_STRING_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-ctl-vector was given.
-if test "${enable_benchmark_ctl_vector+set}" = set; then :
-  enableval=$enable_benchmark_ctl_vector; case "${enableval}" in
-      yes) benchmark_ctl_vector=true ;;
-      no)  benchmark_ctl_vector=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-ctl-vector" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_ctl_vector = xtrue; then
-  ENABLED_BENCHMARK_CTL_VECTOR_TRUE=
-  ENABLED_BENCHMARK_CTL_VECTOR_FALSE='#'
-else
-  ENABLED_BENCHMARK_CTL_VECTOR_TRUE='#'
-  ENABLED_BENCHMARK_CTL_VECTOR_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-cubic was given.
-if test "${enable_benchmark_cubic+set}" = set; then :
-  enableval=$enable_benchmark_cubic; case "${enableval}" in
-      yes) benchmark_cubic=true ;;
-      no)  benchmark_cubic=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-cubic" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_cubic = xtrue; then
-  ENABLED_BENCHMARK_CUBIC_TRUE=
-  ENABLED_BENCHMARK_CUBIC_FALSE='#'
-else
-  ENABLED_BENCHMARK_CUBIC_TRUE='#'
-  ENABLED_BENCHMARK_CUBIC_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-dijkstra was given.
-if test "${enable_benchmark_dijkstra+set}" = set; then :
-  enableval=$enable_benchmark_dijkstra; case "${enableval}" in
-      yes) benchmark_dijkstra=true ;;
-      no)  benchmark_dijkstra=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-dijkstra" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_dijkstra = xtrue; then
-  ENABLED_BENCHMARK_DIJKSTRA_TRUE=
-  ENABLED_BENCHMARK_DIJKSTRA_FALSE='#'
-else
-  ENABLED_BENCHMARK_DIJKSTRA_TRUE='#'
-  ENABLED_BENCHMARK_DIJKSTRA_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-dtoa was given.
-if test "${enable_benchmark_dtoa+set}" = set; then :
-  enableval=$enable_benchmark_dtoa; case "${enableval}" in
-      yes) benchmark_dtoa=true ;;
-      no)  benchmark_dtoa=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-dtoa" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_dtoa = xtrue; then
-  ENABLED_BENCHMARK_DTOA_TRUE=
-  ENABLED_BENCHMARK_DTOA_FALSE='#'
-else
-  ENABLED_BENCHMARK_DTOA_TRUE='#'
-  ENABLED_BENCHMARK_DTOA_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-duff was given.
-if test "${enable_benchmark_duff+set}" = set; then :
-  enableval=$enable_benchmark_duff; case "${enableval}" in
-      yes) benchmark_duff=true ;;
-      no)  benchmark_duff=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-duff" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_duff = xtrue; then
-  ENABLED_BENCHMARK_DUFF_TRUE=
-  ENABLED_BENCHMARK_DUFF_FALSE='#'
-else
-  ENABLED_BENCHMARK_DUFF_TRUE='#'
-  ENABLED_BENCHMARK_DUFF_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-edn was given.
-if test "${enable_benchmark_edn+set}" = set; then :
-  enableval=$enable_benchmark_edn; case "${enableval}" in
-      yes) benchmark_edn=true ;;
-      no)  benchmark_edn=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-edn" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_edn = xtrue; then
-  ENABLED_BENCHMARK_EDN_TRUE=
-  ENABLED_BENCHMARK_EDN_FALSE='#'
-else
-  ENABLED_BENCHMARK_EDN_TRUE='#'
-  ENABLED_BENCHMARK_EDN_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-expint was given.
-if test "${enable_benchmark_expint+set}" = set; then :
-  enableval=$enable_benchmark_expint; case "${enableval}" in
-      yes) benchmark_expint=true ;;
-      no)  benchmark_expint=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-expint" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_expint = xtrue; then
-  ENABLED_BENCHMARK_EXPINT_TRUE=
-  ENABLED_BENCHMARK_EXPINT_FALSE='#'
-else
-  ENABLED_BENCHMARK_EXPINT_TRUE='#'
-  ENABLED_BENCHMARK_EXPINT_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-fac was given.
-if test "${enable_benchmark_fac+set}" = set; then :
-  enableval=$enable_benchmark_fac; case "${enableval}" in
-      yes) benchmark_fac=true ;;
-      no)  benchmark_fac=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-fac" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_fac = xtrue; then
-  ENABLED_BENCHMARK_FAC_TRUE=
-  ENABLED_BENCHMARK_FAC_FALSE='#'
-else
-  ENABLED_BENCHMARK_FAC_TRUE='#'
-  ENABLED_BENCHMARK_FAC_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-fasta was given.
-if test "${enable_benchmark_fasta+set}" = set; then :
-  enableval=$enable_benchmark_fasta; case "${enableval}" in
-      yes) benchmark_fasta=true ;;
-      no)  benchmark_fasta=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-fasta" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_fasta = xtrue; then
-  ENABLED_BENCHMARK_FASTA_TRUE=
-  ENABLED_BENCHMARK_FASTA_FALSE='#'
-else
-  ENABLED_BENCHMARK_FASTA_TRUE='#'
-  ENABLED_BENCHMARK_FASTA_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-fdct was given.
-if test "${enable_benchmark_fdct+set}" = set; then :
-  enableval=$enable_benchmark_fdct; case "${enableval}" in
-      yes) benchmark_fdct=true ;;
-      no)  benchmark_fdct=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-fdct" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_fdct = xtrue; then
-  ENABLED_BENCHMARK_FDCT_TRUE=
-  ENABLED_BENCHMARK_FDCT_FALSE='#'
-else
-  ENABLED_BENCHMARK_FDCT_TRUE='#'
-  ENABLED_BENCHMARK_FDCT_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-fibcall was given.
-if test "${enable_benchmark_fibcall+set}" = set; then :
-  enableval=$enable_benchmark_fibcall; case "${enableval}" in
-      yes) benchmark_fibcall=true ;;
-      no)  benchmark_fibcall=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-fibcall" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_fibcall = xtrue; then
-  ENABLED_BENCHMARK_FIBCALL_TRUE=
-  ENABLED_BENCHMARK_FIBCALL_FALSE='#'
-else
-  ENABLED_BENCHMARK_FIBCALL_TRUE='#'
-  ENABLED_BENCHMARK_FIBCALL_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-fir was given.
-if test "${enable_benchmark_fir+set}" = set; then :
-  enableval=$enable_benchmark_fir; case "${enableval}" in
-      yes) benchmark_fir=true ;;
-      no)  benchmark_fir=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-fir" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_fir = xtrue; then
-  ENABLED_BENCHMARK_FIR_TRUE=
-  ENABLED_BENCHMARK_FIR_FALSE='#'
-else
-  ENABLED_BENCHMARK_FIR_TRUE='#'
-  ENABLED_BENCHMARK_FIR_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-frac was given.
-if test "${enable_benchmark_frac+set}" = set; then :
-  enableval=$enable_benchmark_frac; case "${enableval}" in
-      yes) benchmark_frac=true ;;
-      no)  benchmark_frac=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-frac" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_frac = xtrue; then
-  ENABLED_BENCHMARK_FRAC_TRUE=
-  ENABLED_BENCHMARK_FRAC_FALSE='#'
-else
-  ENABLED_BENCHMARK_FRAC_TRUE='#'
-  ENABLED_BENCHMARK_FRAC_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-huffbench was given.
-if test "${enable_benchmark_huffbench+set}" = set; then :
-  enableval=$enable_benchmark_huffbench; case "${enableval}" in
-      yes) benchmark_huffbench=true ;;
-      no)  benchmark_huffbench=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-huffbench" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_huffbench = xtrue; then
-  ENABLED_BENCHMARK_HUFFBENCH_TRUE=
-  ENABLED_BENCHMARK_HUFFBENCH_FALSE='#'
-else
-  ENABLED_BENCHMARK_HUFFBENCH_TRUE='#'
-  ENABLED_BENCHMARK_HUFFBENCH_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-insertsort was given.
-if test "${enable_benchmark_insertsort+set}" = set; then :
-  enableval=$enable_benchmark_insertsort; case "${enableval}" in
-      yes) benchmark_insertsort=true ;;
-      no)  benchmark_insertsort=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-insertsort" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_insertsort = xtrue; then
-  ENABLED_BENCHMARK_INSERTSORT_TRUE=
-  ENABLED_BENCHMARK_INSERTSORT_FALSE='#'
-else
-  ENABLED_BENCHMARK_INSERTSORT_TRUE='#'
-  ENABLED_BENCHMARK_INSERTSORT_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-janne_complex was given.
-if test "${enable_benchmark_janne_complex+set}" = set; then :
-  enableval=$enable_benchmark_janne_complex; case "${enableval}" in
-      yes) benchmark_janne_complex=true ;;
-      no)  benchmark_janne_complex=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-janne_complex" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_janne_complex = xtrue; then
-  ENABLED_BENCHMARK_JANNE_COMPLEX_TRUE=
-  ENABLED_BENCHMARK_JANNE_COMPLEX_FALSE='#'
-else
-  ENABLED_BENCHMARK_JANNE_COMPLEX_TRUE='#'
-  ENABLED_BENCHMARK_JANNE_COMPLEX_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-jfdctint was given.
-if test "${enable_benchmark_jfdctint+set}" = set; then :
-  enableval=$enable_benchmark_jfdctint; case "${enableval}" in
-      yes) benchmark_jfdctint=true ;;
-      no)  benchmark_jfdctint=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-jfdctint" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_jfdctint = xtrue; then
-  ENABLED_BENCHMARK_JFDCTINT_TRUE=
-  ENABLED_BENCHMARK_JFDCTINT_FALSE='#'
-else
-  ENABLED_BENCHMARK_JFDCTINT_TRUE='#'
-  ENABLED_BENCHMARK_JFDCTINT_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-lcdnum was given.
-if test "${enable_benchmark_lcdnum+set}" = set; then :
-  enableval=$enable_benchmark_lcdnum; case "${enableval}" in
-      yes) benchmark_lcdnum=true ;;
-      no)  benchmark_lcdnum=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-lcdnum" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_lcdnum = xtrue; then
-  ENABLED_BENCHMARK_LCDNUM_TRUE=
-  ENABLED_BENCHMARK_LCDNUM_FALSE='#'
-else
-  ENABLED_BENCHMARK_LCDNUM_TRUE='#'
-  ENABLED_BENCHMARK_LCDNUM_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-levenshtein was given.
-if test "${enable_benchmark_levenshtein+set}" = set; then :
-  enableval=$enable_benchmark_levenshtein; case "${enableval}" in
-      yes) benchmark_levenshtein=true ;;
-      no)  benchmark_levenshtein=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-levenshtein" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_levenshtein = xtrue; then
-  ENABLED_BENCHMARK_LEVENSHTEIN_TRUE=
-  ENABLED_BENCHMARK_LEVENSHTEIN_FALSE='#'
-else
-  ENABLED_BENCHMARK_LEVENSHTEIN_TRUE='#'
-  ENABLED_BENCHMARK_LEVENSHTEIN_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-ludcmp was given.
-if test "${enable_benchmark_ludcmp+set}" = set; then :
-  enableval=$enable_benchmark_ludcmp; case "${enableval}" in
-      yes) benchmark_ludcmp=true ;;
-      no)  benchmark_ludcmp=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-ludcmp" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_ludcmp = xtrue; then
-  ENABLED_BENCHMARK_LUDCMP_TRUE=
-  ENABLED_BENCHMARK_LUDCMP_FALSE='#'
-else
-  ENABLED_BENCHMARK_LUDCMP_TRUE='#'
-  ENABLED_BENCHMARK_LUDCMP_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-matmult-float was given.
-if test "${enable_benchmark_matmult_float+set}" = set; then :
-  enableval=$enable_benchmark_matmult_float; case "${enableval}" in
-      yes) benchmark_matmult_float=true ;;
-      no)  benchmark_matmult_float=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-matmult-float" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_matmult_float = xtrue; then
-  ENABLED_BENCHMARK_MATMULT_FLOAT_TRUE=
-  ENABLED_BENCHMARK_MATMULT_FLOAT_FALSE='#'
-else
-  ENABLED_BENCHMARK_MATMULT_FLOAT_TRUE='#'
-  ENABLED_BENCHMARK_MATMULT_FLOAT_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-matmult-int was given.
-if test "${enable_benchmark_matmult_int+set}" = set; then :
-  enableval=$enable_benchmark_matmult_int; case "${enableval}" in
-      yes) benchmark_matmult_int=true ;;
-      no)  benchmark_matmult_int=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-matmult-int" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_matmult_int = xtrue; then
-  ENABLED_BENCHMARK_MATMULT_INT_TRUE=
-  ENABLED_BENCHMARK_MATMULT_INT_FALSE='#'
-else
-  ENABLED_BENCHMARK_MATMULT_INT_TRUE='#'
-  ENABLED_BENCHMARK_MATMULT_INT_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-mergesort was given.
-if test "${enable_benchmark_mergesort+set}" = set; then :
-  enableval=$enable_benchmark_mergesort; case "${enableval}" in
-      yes) benchmark_mergesort=true ;;
-      no)  benchmark_mergesort=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-mergesort" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_mergesort = xtrue; then
-  ENABLED_BENCHMARK_MERGESORT_TRUE=
-  ENABLED_BENCHMARK_MERGESORT_FALSE='#'
-else
-  ENABLED_BENCHMARK_MERGESORT_TRUE='#'
-  ENABLED_BENCHMARK_MERGESORT_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-miniz was given.
-if test "${enable_benchmark_miniz+set}" = set; then :
-  enableval=$enable_benchmark_miniz; case "${enableval}" in
-      yes) benchmark_miniz=true ;;
-      no)  benchmark_miniz=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-miniz" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_miniz = xtrue; then
-  ENABLED_BENCHMARK_MINIZ_TRUE=
-  ENABLED_BENCHMARK_MINIZ_FALSE='#'
-else
-  ENABLED_BENCHMARK_MINIZ_TRUE='#'
-  ENABLED_BENCHMARK_MINIZ_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-minver was given.
-if test "${enable_benchmark_minver+set}" = set; then :
-  enableval=$enable_benchmark_minver; case "${enableval}" in
-      yes) benchmark_minver=true ;;
-      no)  benchmark_minver=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-minver" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_minver = xtrue; then
-  ENABLED_BENCHMARK_MINVER_TRUE=
-  ENABLED_BENCHMARK_MINVER_FALSE='#'
-else
-  ENABLED_BENCHMARK_MINVER_TRUE='#'
-  ENABLED_BENCHMARK_MINVER_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-nbody was given.
-if test "${enable_benchmark_nbody+set}" = set; then :
-  enableval=$enable_benchmark_nbody; case "${enableval}" in
-      yes) benchmark_nbody=true ;;
-      no)  benchmark_nbody=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-nbody" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_nbody = xtrue; then
-  ENABLED_BENCHMARK_NBODY_TRUE=
-  ENABLED_BENCHMARK_NBODY_FALSE='#'
-else
-  ENABLED_BENCHMARK_NBODY_TRUE='#'
-  ENABLED_BENCHMARK_NBODY_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-ndes was given.
-if test "${enable_benchmark_ndes+set}" = set; then :
-  enableval=$enable_benchmark_ndes; case "${enableval}" in
-      yes) benchmark_ndes=true ;;
-      no)  benchmark_ndes=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-ndes" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_ndes = xtrue; then
-  ENABLED_BENCHMARK_NDES_TRUE=
-  ENABLED_BENCHMARK_NDES_FALSE='#'
-else
-  ENABLED_BENCHMARK_NDES_TRUE='#'
-  ENABLED_BENCHMARK_NDES_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-nettle-arcfour was given.
-if test "${enable_benchmark_nettle_arcfour+set}" = set; then :
-  enableval=$enable_benchmark_nettle_arcfour; case "${enableval}" in
-      yes) benchmark_nettle_arcfour=true ;;
-      no)  benchmark_nettle_arcfour=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-nettle-arcfour" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_nettle_arcfour = xtrue; then
-  ENABLED_BENCHMARK_NETTLE_ARCFOUR_TRUE=
-  ENABLED_BENCHMARK_NETTLE_ARCFOUR_FALSE='#'
-else
-  ENABLED_BENCHMARK_NETTLE_ARCFOUR_TRUE='#'
-  ENABLED_BENCHMARK_NETTLE_ARCFOUR_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-nettle-cast128 was given.
-if test "${enable_benchmark_nettle_cast128+set}" = set; then :
-  enableval=$enable_benchmark_nettle_cast128; case "${enableval}" in
-      yes) benchmark_nettle_cast128=true ;;
-      no)  benchmark_nettle_cast128=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-nettle-cast128" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_nettle_cast128 = xtrue; then
-  ENABLED_BENCHMARK_NETTLE_CAST128_TRUE=
-  ENABLED_BENCHMARK_NETTLE_CAST128_FALSE='#'
-else
-  ENABLED_BENCHMARK_NETTLE_CAST128_TRUE='#'
-  ENABLED_BENCHMARK_NETTLE_CAST128_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-nettle-des was given.
-if test "${enable_benchmark_nettle_des+set}" = set; then :
-  enableval=$enable_benchmark_nettle_des; case "${enableval}" in
-      yes) benchmark_nettle_des=true ;;
-      no)  benchmark_nettle_des=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-nettle-des" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_nettle_des = xtrue; then
-  ENABLED_BENCHMARK_NETTLE_DES_TRUE=
-  ENABLED_BENCHMARK_NETTLE_DES_FALSE='#'
-else
-  ENABLED_BENCHMARK_NETTLE_DES_TRUE='#'
-  ENABLED_BENCHMARK_NETTLE_DES_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-nettle-md5 was given.
-if test "${enable_benchmark_nettle_md5+set}" = set; then :
-  enableval=$enable_benchmark_nettle_md5; case "${enableval}" in
-      yes) benchmark_nettle_md5=true ;;
-      no)  benchmark_nettle_md5=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-nettle-md5" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_nettle_md5 = xtrue; then
-  ENABLED_BENCHMARK_NETTLE_MD5_TRUE=
-  ENABLED_BENCHMARK_NETTLE_MD5_FALSE='#'
-else
-  ENABLED_BENCHMARK_NETTLE_MD5_TRUE='#'
-  ENABLED_BENCHMARK_NETTLE_MD5_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-nettle-sha256 was given.
-if test "${enable_benchmark_nettle_sha256+set}" = set; then :
-  enableval=$enable_benchmark_nettle_sha256; case "${enableval}" in
-      yes) benchmark_nettle_sha256=true ;;
-      no)  benchmark_nettle_sha256=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-nettle-sha256" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_nettle_sha256 = xtrue; then
-  ENABLED_BENCHMARK_NETTLE_SHA256_TRUE=
-  ENABLED_BENCHMARK_NETTLE_SHA256_FALSE='#'
-else
-  ENABLED_BENCHMARK_NETTLE_SHA256_TRUE='#'
-  ENABLED_BENCHMARK_NETTLE_SHA256_FALSE=
-fi
-
-
-
-# Check whether --enable-benchmark-newlib-exp was given.
-if test "${enable_benchmark_newlib_exp+set}" = set; then :
-  enableval=$enable_benchmark_newlib_exp; case "${enableval}" in
-      yes) benchmark_newlib_exp=true ;;
-      no)  benchmark_newlib_exp=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-newlib-exp" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_newlib_exp = xtrue; then
-  ENABLED_BENCHMARK_NEWLIB_EXP_TRUE=
-  ENABLED_BENCHMARK_NEWLIB_EXP_FALSE='#'
-else
-  ENABLED_BENCHMARK_NEWLIB_EXP_TRUE='#'
-  ENABLED_BENCHMARK_NEWLIB_EXP_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-newlib-log was given.
-if test "${enable_benchmark_newlib_log+set}" = set; then :
-  enableval=$enable_benchmark_newlib_log; case "${enableval}" in
-      yes) benchmark_newlib_log=true ;;
-      no)  benchmark_newlib_log=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-newlib-log" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_newlib_log = xtrue; then
-  ENABLED_BENCHMARK_NEWLIB_LOG_TRUE=
-  ENABLED_BENCHMARK_NEWLIB_LOG_FALSE='#'
-else
-  ENABLED_BENCHMARK_NEWLIB_LOG_TRUE='#'
-  ENABLED_BENCHMARK_NEWLIB_LOG_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-newlib-mod was given.
-if test "${enable_benchmark_newlib_mod+set}" = set; then :
-  enableval=$enable_benchmark_newlib_mod; case "${enableval}" in
-      yes) benchmark_newlib_mod=true ;;
-      no)  benchmark_newlib_mod=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-newlib-mod" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_newlib_mod = xtrue; then
-  ENABLED_BENCHMARK_NEWLIB_MOD_TRUE=
-  ENABLED_BENCHMARK_NEWLIB_MOD_FALSE='#'
-else
-  ENABLED_BENCHMARK_NEWLIB_MOD_TRUE='#'
-  ENABLED_BENCHMARK_NEWLIB_MOD_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-newlib-sqrt was given.
-if test "${enable_benchmark_newlib_sqrt+set}" = set; then :
-  enableval=$enable_benchmark_newlib_sqrt; case "${enableval}" in
-      yes) benchmark_newlib_sqrt=true ;;
-      no)  benchmark_newlib_sqrt=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-newlib-sqrt" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_newlib_sqrt = xtrue; then
-  ENABLED_BENCHMARK_NEWLIB_SQRT_TRUE=
-  ENABLED_BENCHMARK_NEWLIB_SQRT_FALSE='#'
-else
-  ENABLED_BENCHMARK_NEWLIB_SQRT_TRUE='#'
-  ENABLED_BENCHMARK_NEWLIB_SQRT_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-ns was given.
-if test "${enable_benchmark_ns+set}" = set; then :
-  enableval=$enable_benchmark_ns; case "${enableval}" in
-      yes) benchmark_ns=true ;;
-      no)  benchmark_ns=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-ns" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_ns = xtrue; then
-  ENABLED_BENCHMARK_NS_TRUE=
-  ENABLED_BENCHMARK_NS_FALSE='#'
-else
-  ENABLED_BENCHMARK_NS_TRUE='#'
-  ENABLED_BENCHMARK_NS_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-nsichneu was given.
-if test "${enable_benchmark_nsichneu+set}" = set; then :
-  enableval=$enable_benchmark_nsichneu; case "${enableval}" in
-      yes) benchmark_nsichneu=true ;;
-      no)  benchmark_nsichneu=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-nsichneu" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_nsichneu = xtrue; then
-  ENABLED_BENCHMARK_NSICHNEU_TRUE=
-  ENABLED_BENCHMARK_NSICHNEU_FALSE='#'
-else
-  ENABLED_BENCHMARK_NSICHNEU_TRUE='#'
-  ENABLED_BENCHMARK_NSICHNEU_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-picojpeg was given.
-if test "${enable_benchmark_picojpeg+set}" = set; then :
-  enableval=$enable_benchmark_picojpeg; case "${enableval}" in
-      yes) benchmark_picojpeg=true ;;
-      no)  benchmark_picojpeg=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-picojpeg" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_picojpeg = xtrue; then
-  ENABLED_BENCHMARK_PICOJPEG_TRUE=
-  ENABLED_BENCHMARK_PICOJPEG_FALSE='#'
-else
-  ENABLED_BENCHMARK_PICOJPEG_TRUE='#'
-  ENABLED_BENCHMARK_PICOJPEG_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-prime was given.
-if test "${enable_benchmark_prime+set}" = set; then :
-  enableval=$enable_benchmark_prime; case "${enableval}" in
-      yes) benchmark_prime=true ;;
-      no)  benchmark_prime=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-prime" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_prime = xtrue; then
-  ENABLED_BENCHMARK_PRIME_TRUE=
-  ENABLED_BENCHMARK_PRIME_FALSE='#'
-else
-  ENABLED_BENCHMARK_PRIME_TRUE='#'
-  ENABLED_BENCHMARK_PRIME_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-qrduino was given.
-if test "${enable_benchmark_qrduino+set}" = set; then :
-  enableval=$enable_benchmark_qrduino; case "${enableval}" in
-      yes) benchmark_qrduino=true ;;
-      no)  benchmark_qrduino=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-qrduino" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_qrduino = xtrue; then
-  ENABLED_BENCHMARK_QRDUINO_TRUE=
-  ENABLED_BENCHMARK_QRDUINO_FALSE='#'
-else
-  ENABLED_BENCHMARK_QRDUINO_TRUE='#'
-  ENABLED_BENCHMARK_QRDUINO_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-qsort was given.
-if test "${enable_benchmark_qsort+set}" = set; then :
-  enableval=$enable_benchmark_qsort; case "${enableval}" in
-      yes) benchmark_qsort=true ;;
-      no)  benchmark_qsort=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-qsort" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_qsort = xtrue; then
-  ENABLED_BENCHMARK_QSORT_TRUE=
-  ENABLED_BENCHMARK_QSORT_FALSE='#'
-else
-  ENABLED_BENCHMARK_QSORT_TRUE='#'
-  ENABLED_BENCHMARK_QSORT_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-qurt was given.
-if test "${enable_benchmark_qurt+set}" = set; then :
-  enableval=$enable_benchmark_qurt; case "${enableval}" in
-      yes) benchmark_qurt=true ;;
-      no)  benchmark_qurt=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-qurt" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_qurt = xtrue; then
-  ENABLED_BENCHMARK_QURT_TRUE=
-  ENABLED_BENCHMARK_QURT_FALSE='#'
-else
-  ENABLED_BENCHMARK_QURT_TRUE='#'
-  ENABLED_BENCHMARK_QURT_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-recursion was given.
-if test "${enable_benchmark_recursion+set}" = set; then :
-  enableval=$enable_benchmark_recursion; case "${enableval}" in
-      yes) benchmark_recursion=true ;;
-      no)  benchmark_recursion=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-recursion" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_recursion = xtrue; then
-  ENABLED_BENCHMARK_RECURSION_TRUE=
-  ENABLED_BENCHMARK_RECURSION_FALSE='#'
-else
-  ENABLED_BENCHMARK_RECURSION_TRUE='#'
-  ENABLED_BENCHMARK_RECURSION_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-rijndael was given.
-if test "${enable_benchmark_rijndael+set}" = set; then :
-  enableval=$enable_benchmark_rijndael; case "${enableval}" in
-      yes) benchmark_rijndael=true ;;
-      no)  benchmark_rijndael=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-rijndael" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_rijndael = xtrue; then
-  ENABLED_BENCHMARK_RIJNDAEL_TRUE=
-  ENABLED_BENCHMARK_RIJNDAEL_FALSE='#'
-else
-  ENABLED_BENCHMARK_RIJNDAEL_TRUE='#'
-  ENABLED_BENCHMARK_RIJNDAEL_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-select was given.
-if test "${enable_benchmark_select+set}" = set; then :
-  enableval=$enable_benchmark_select; case "${enableval}" in
-      yes) benchmark_select=true ;;
-      no)  benchmark_select=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-select" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_select = xtrue; then
-  ENABLED_BENCHMARK_SELECT_TRUE=
-  ENABLED_BENCHMARK_SELECT_FALSE='#'
-else
-  ENABLED_BENCHMARK_SELECT_TRUE='#'
-  ENABLED_BENCHMARK_SELECT_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-sglib-arraybinsearch was given.
-if test "${enable_benchmark_sglib_arraybinsearch+set}" = set; then :
-  enableval=$enable_benchmark_sglib_arraybinsearch; case "${enableval}" in
-      yes) benchmark_sglib_arraybinsearch=true ;;
-      no)  benchmark_sglib_arraybinsearch=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-sglib-arraybinsearch" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_sglib_arraybinsearch = xtrue; then
-  ENABLED_BENCHMARK_SGLIB_ARRAYBINSEARCH_TRUE=
-  ENABLED_BENCHMARK_SGLIB_ARRAYBINSEARCH_FALSE='#'
-else
-  ENABLED_BENCHMARK_SGLIB_ARRAYBINSEARCH_TRUE='#'
-  ENABLED_BENCHMARK_SGLIB_ARRAYBINSEARCH_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-sglib-arrayheapsort was given.
-if test "${enable_benchmark_sglib_arrayheapsort+set}" = set; then :
-  enableval=$enable_benchmark_sglib_arrayheapsort; case "${enableval}" in
-      yes) benchmark_sglib_arrayheapsort=true ;;
-      no)  benchmark_sglib_arrayheapsort=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-sglib-arrayheapsort" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_sglib_arrayheapsort = xtrue; then
-  ENABLED_BENCHMARK_SGLIB_ARRAYHEAPSORT_TRUE=
-  ENABLED_BENCHMARK_SGLIB_ARRAYHEAPSORT_FALSE='#'
-else
-  ENABLED_BENCHMARK_SGLIB_ARRAYHEAPSORT_TRUE='#'
-  ENABLED_BENCHMARK_SGLIB_ARRAYHEAPSORT_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-sglib-arrayquicksort was given.
-if test "${enable_benchmark_sglib_arrayquicksort+set}" = set; then :
-  enableval=$enable_benchmark_sglib_arrayquicksort; case "${enableval}" in
-      yes) benchmark_sglib_arrayquicksort=true ;;
-      no)  benchmark_sglib_arrayquicksort=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-sglib-arrayquicksort" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_sglib_arrayquicksort = xtrue; then
-  ENABLED_BENCHMARK_SGLIB_ARRAYQUICKSORT_TRUE=
-  ENABLED_BENCHMARK_SGLIB_ARRAYQUICKSORT_FALSE='#'
-else
-  ENABLED_BENCHMARK_SGLIB_ARRAYQUICKSORT_TRUE='#'
-  ENABLED_BENCHMARK_SGLIB_ARRAYQUICKSORT_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-sglib-dllist was given.
-if test "${enable_benchmark_sglib_dllist+set}" = set; then :
-  enableval=$enable_benchmark_sglib_dllist; case "${enableval}" in
-      yes) benchmark_sglib_dllist=true ;;
-      no)  benchmark_sglib_dllist=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-sglib-dllist" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_sglib_dllist = xtrue; then
-  ENABLED_BENCHMARK_SGLIB_DLLIST_TRUE=
-  ENABLED_BENCHMARK_SGLIB_DLLIST_FALSE='#'
-else
-  ENABLED_BENCHMARK_SGLIB_DLLIST_TRUE='#'
-  ENABLED_BENCHMARK_SGLIB_DLLIST_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-sglib-hashtable was given.
-if test "${enable_benchmark_sglib_hashtable+set}" = set; then :
-  enableval=$enable_benchmark_sglib_hashtable; case "${enableval}" in
-      yes) benchmark_sglib_hashtable=true ;;
-      no)  benchmark_sglib_hashtable=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-sglib-hashtable" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_sglib_hashtable = xtrue; then
-  ENABLED_BENCHMARK_SGLIB_HASHTABLE_TRUE=
-  ENABLED_BENCHMARK_SGLIB_HASHTABLE_FALSE='#'
-else
-  ENABLED_BENCHMARK_SGLIB_HASHTABLE_TRUE='#'
-  ENABLED_BENCHMARK_SGLIB_HASHTABLE_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-sglib-listinsertsort was given.
-if test "${enable_benchmark_sglib_listinsertsort+set}" = set; then :
-  enableval=$enable_benchmark_sglib_listinsertsort; case "${enableval}" in
-      yes) benchmark_sglib_listinsertsort=true ;;
-      no)  benchmark_sglib_listinsertsort=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-sglib-listinsertsort" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_sglib_listinsertsort = xtrue; then
-  ENABLED_BENCHMARK_SGLIB_LISTINSERTSORT_TRUE=
-  ENABLED_BENCHMARK_SGLIB_LISTINSERTSORT_FALSE='#'
-else
-  ENABLED_BENCHMARK_SGLIB_LISTINSERTSORT_TRUE='#'
-  ENABLED_BENCHMARK_SGLIB_LISTINSERTSORT_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-sglib-listsort was given.
-if test "${enable_benchmark_sglib_listsort+set}" = set; then :
-  enableval=$enable_benchmark_sglib_listsort; case "${enableval}" in
-      yes) benchmark_sglib_listsort=true ;;
-      no)  benchmark_sglib_listsort=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-sglib-listsort" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_sglib_listsort = xtrue; then
-  ENABLED_BENCHMARK_SGLIB_LISTSORT_TRUE=
-  ENABLED_BENCHMARK_SGLIB_LISTSORT_FALSE='#'
-else
-  ENABLED_BENCHMARK_SGLIB_LISTSORT_TRUE='#'
-  ENABLED_BENCHMARK_SGLIB_LISTSORT_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-sglib-queue was given.
-if test "${enable_benchmark_sglib_queue+set}" = set; then :
-  enableval=$enable_benchmark_sglib_queue; case "${enableval}" in
-      yes) benchmark_sglib_queue=true ;;
-      no)  benchmark_sglib_queue=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-sglib-queue" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_sglib_queue = xtrue; then
-  ENABLED_BENCHMARK_SGLIB_QUEUE_TRUE=
-  ENABLED_BENCHMARK_SGLIB_QUEUE_FALSE='#'
-else
-  ENABLED_BENCHMARK_SGLIB_QUEUE_TRUE='#'
-  ENABLED_BENCHMARK_SGLIB_QUEUE_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-sglib-rbtree was given.
-if test "${enable_benchmark_sglib_rbtree+set}" = set; then :
-  enableval=$enable_benchmark_sglib_rbtree; case "${enableval}" in
-      yes) benchmark_sglib_rbtree=true ;;
-      no)  benchmark_sglib_rbtree=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-sglib-rbtree" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_sglib_rbtree = xtrue; then
-  ENABLED_BENCHMARK_SGLIB_RBTREE_TRUE=
-  ENABLED_BENCHMARK_SGLIB_RBTREE_FALSE='#'
-else
-  ENABLED_BENCHMARK_SGLIB_RBTREE_TRUE='#'
-  ENABLED_BENCHMARK_SGLIB_RBTREE_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-slre was given.
-if test "${enable_benchmark_slre+set}" = set; then :
-  enableval=$enable_benchmark_slre; case "${enableval}" in
-      yes) benchmark_slre=true ;;
-      no)  benchmark_slre=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-slre" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_slre = xtrue; then
-  ENABLED_BENCHMARK_SLRE_TRUE=
-  ENABLED_BENCHMARK_SLRE_FALSE='#'
-else
-  ENABLED_BENCHMARK_SLRE_TRUE='#'
-  ENABLED_BENCHMARK_SLRE_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-sqrt was given.
-if test "${enable_benchmark_sqrt+set}" = set; then :
-  enableval=$enable_benchmark_sqrt; case "${enableval}" in
-      yes) benchmark_sqrt=true ;;
-      no)  benchmark_sqrt=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-sqrt" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_sqrt = xtrue; then
-  ENABLED_BENCHMARK_SQRT_TRUE=
-  ENABLED_BENCHMARK_SQRT_FALSE='#'
-else
-  ENABLED_BENCHMARK_SQRT_TRUE='#'
-  ENABLED_BENCHMARK_SQRT_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-st was given.
-if test "${enable_benchmark_st+set}" = set; then :
-  enableval=$enable_benchmark_st; case "${enableval}" in
-      yes) benchmark_st=true ;;
-      no)  benchmark_st=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-st" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_st = xtrue; then
-  ENABLED_BENCHMARK_ST_TRUE=
-  ENABLED_BENCHMARK_ST_FALSE='#'
-else
-  ENABLED_BENCHMARK_ST_TRUE='#'
-  ENABLED_BENCHMARK_ST_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-statemate was given.
-if test "${enable_benchmark_statemate+set}" = set; then :
-  enableval=$enable_benchmark_statemate; case "${enableval}" in
-      yes) benchmark_statemate=true ;;
-      no)  benchmark_statemate=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-statemate" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_statemate = xtrue; then
-  ENABLED_BENCHMARK_STATEMATE_TRUE=
-  ENABLED_BENCHMARK_STATEMATE_FALSE='#'
-else
-  ENABLED_BENCHMARK_STATEMATE_TRUE='#'
-  ENABLED_BENCHMARK_STATEMATE_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-stb_perlin was given.
-if test "${enable_benchmark_stb_perlin+set}" = set; then :
-  enableval=$enable_benchmark_stb_perlin; case "${enableval}" in
-      yes) benchmark_stb_perlin=true ;;
-      no)  benchmark_stb_perlin=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-stb_perlin" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_stb_perlin = xtrue; then
-  ENABLED_BENCHMARK_STB_PERLIN_TRUE=
-  ENABLED_BENCHMARK_STB_PERLIN_FALSE='#'
-else
-  ENABLED_BENCHMARK_STB_PERLIN_TRUE='#'
-  ENABLED_BENCHMARK_STB_PERLIN_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-stringsearch1 was given.
-if test "${enable_benchmark_stringsearch1+set}" = set; then :
-  enableval=$enable_benchmark_stringsearch1; case "${enableval}" in
-      yes) benchmark_stringsearch1=true ;;
-      no)  benchmark_stringsearch1=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-stringsearch1" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_stringsearch1 = xtrue; then
-  ENABLED_BENCHMARK_STRINGSEARCH1_TRUE=
-  ENABLED_BENCHMARK_STRINGSEARCH1_FALSE='#'
-else
-  ENABLED_BENCHMARK_STRINGSEARCH1_TRUE='#'
-  ENABLED_BENCHMARK_STRINGSEARCH1_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-strstr was given.
-if test "${enable_benchmark_strstr+set}" = set; then :
-  enableval=$enable_benchmark_strstr; case "${enableval}" in
-      yes) benchmark_strstr=true ;;
-      no)  benchmark_strstr=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-strstr" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_strstr = xtrue; then
-  ENABLED_BENCHMARK_STRSTR_TRUE=
-  ENABLED_BENCHMARK_STRSTR_FALSE='#'
-else
-  ENABLED_BENCHMARK_STRSTR_TRUE='#'
-  ENABLED_BENCHMARK_STRSTR_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-tarai was given.
-if test "${enable_benchmark_tarai+set}" = set; then :
-  enableval=$enable_benchmark_tarai; case "${enableval}" in
-      yes) benchmark_tarai=true ;;
-      no)  benchmark_tarai=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-tarai" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_tarai = xtrue; then
-  ENABLED_BENCHMARK_TARAI_TRUE=
-  ENABLED_BENCHMARK_TARAI_FALSE='#'
-else
-  ENABLED_BENCHMARK_TARAI_TRUE='#'
-  ENABLED_BENCHMARK_TARAI_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-template was given.
-if test "${enable_benchmark_template+set}" = set; then :
-  enableval=$enable_benchmark_template; case "${enableval}" in
-      yes) benchmark_template=true ;;
-      no)  benchmark_template=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-template" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_template = xtrue; then
-  ENABLED_BENCHMARK_TEMPLATE_TRUE=
-  ENABLED_BENCHMARK_TEMPLATE_FALSE='#'
-else
-  ENABLED_BENCHMARK_TEMPLATE_TRUE='#'
-  ENABLED_BENCHMARK_TEMPLATE_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-trio-snprintf was given.
-if test "${enable_benchmark_trio_snprintf+set}" = set; then :
-  enableval=$enable_benchmark_trio_snprintf; case "${enableval}" in
-      yes) benchmark_trio_snprintf=true ;;
-      no)  benchmark_trio_snprintf=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-trio-snprintf" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_trio_snprintf = xtrue; then
-  ENABLED_BENCHMARK_TRIO_SNPRINTF_TRUE=
-  ENABLED_BENCHMARK_TRIO_SNPRINTF_FALSE='#'
-else
-  ENABLED_BENCHMARK_TRIO_SNPRINTF_TRUE='#'
-  ENABLED_BENCHMARK_TRIO_SNPRINTF_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-trio-sscanf was given.
-if test "${enable_benchmark_trio_sscanf+set}" = set; then :
-  enableval=$enable_benchmark_trio_sscanf; case "${enableval}" in
-      yes) benchmark_trio_sscanf=true ;;
-      no)  benchmark_trio_sscanf=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-trio-sscanf" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_trio_sscanf = xtrue; then
-  ENABLED_BENCHMARK_TRIO_SSCANF_TRUE=
-  ENABLED_BENCHMARK_TRIO_SSCANF_FALSE='#'
-else
-  ENABLED_BENCHMARK_TRIO_SSCANF_TRUE='#'
-  ENABLED_BENCHMARK_TRIO_SSCANF_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-ud was given.
-if test "${enable_benchmark_ud+set}" = set; then :
-  enableval=$enable_benchmark_ud; case "${enableval}" in
-      yes) benchmark_ud=true ;;
-      no)  benchmark_ud=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-ud" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_ud = xtrue; then
-  ENABLED_BENCHMARK_UD_TRUE=
-  ENABLED_BENCHMARK_UD_FALSE='#'
-else
-  ENABLED_BENCHMARK_UD_TRUE='#'
-  ENABLED_BENCHMARK_UD_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-whetstone was given.
-if test "${enable_benchmark_whetstone+set}" = set; then :
-  enableval=$enable_benchmark_whetstone; case "${enableval}" in
-      yes) benchmark_whetstone=true ;;
-      no)  benchmark_whetstone=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-whetstone" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_whetstone = xtrue; then
-  ENABLED_BENCHMARK_WHETSTONE_TRUE=
-  ENABLED_BENCHMARK_WHETSTONE_FALSE='#'
-else
-  ENABLED_BENCHMARK_WHETSTONE_TRUE='#'
-  ENABLED_BENCHMARK_WHETSTONE_FALSE=
-fi
-
-
-# Check whether --enable-benchmark-wikisort was given.
-if test "${enable_benchmark_wikisort+set}" = set; then :
-  enableval=$enable_benchmark_wikisort; case "${enableval}" in
-      yes) benchmark_wikisort=true ;;
-      no)  benchmark_wikisort=false ;;
-      *)   as_fn_error $? "bad value ${enableval} for --enable-benchmark-wikisort" "$LINENO" 5 ;;
-   esac
-fi
-
- if test x$benchmark_wikisort = xtrue; then
-  ENABLED_BENCHMARK_WIKISORT_TRUE=
-  ENABLED_BENCHMARK_WIKISORT_FALSE='#'
-else
-  ENABLED_BENCHMARK_WIKISORT_TRUE='#'
-  ENABLED_BENCHMARK_WIKISORT_FALSE=
-fi
-
-
-
-# What to set DUMMY_* to if the dummy libraries are enabled.
-
-DUMMY_CRT0_YES="\$(top_builddir)/support/libdummycrt0.la"
-DUMMY_LIBGCC_YES="\$(top_builddir)/support/libdummygcc.la"
-DUMMY_COMPILERRT_YES="\$(top_builddir)/support/libdummycompilerrt.la"
-DUMMY_LIBC_YES="-Wl,--start-group \$(top_builddir)/support/libdummyc.la"
-DUMMY_LIBM_YES="\$(top_builddir)/support/libdummym.la"
-
-# Enable dummy libraries
-
-case "${USE_DUMMY_CRT0}" in
-   yes) DUMMY_CRT0=${DUMMY_CRT0_YES} ;;
-   no)  DUMMY_CRT0= ;;
-   *)   DUMMY_CRT0=${USE_DUMMY_CRT0} ;;
-esac
-
-case "${USE_DUMMY_LIBGCC}" in
-   yes) DUMMY_LIBGCC=${DUMMY_LIBGCC_YES} ;;
-   no)  DUMMY_LIBGCC= ;;
-   *)   DUMMY_LIBGCC=${USE_DUMMY_LIBGCC} ;;
-esac
-
-case "${USE_DUMMY_COMPILERRT}" in
-   yes) DUMMY_COMPILERRT=${DUMMY_COMPILERRT_YES} ;;
-   no)  DUMMY_COMPILERRT= ;;
-   *)   DUMMY_COMPILERRT=${USE_DUMMY_COMPILERRT} ;;
-esac
-
-case "${USE_DUMMY_LIBC}" in
-   yes) DUMMY_LIBC=${DUMMY_LIBC_YES} ;;
-   no)  DUMMY_LIBC= ;;
-   *)   DUMMY_LIBC=${USE_DUMMY_LIBC} ;;
-esac
-
-case "${USE_DUMMY_LIBM}" in
-   yes) DUMMY_LIBM=${DUMMY_LIBM_YES} ;;
-   no)  DUMMY_LIBM="-lm" ;;
-   *)   DUMMY_LIBM=${USE_DUMMY_LIBM} ;;
-esac
-
-# Check for support code
-
- if test -f $srcdir/config/$arch/chips/$chip/chipsupport.c; then
-  CHIPSUPPORT_C_TRUE=
-  CHIPSUPPORT_C_FALSE='#'
-else
-  CHIPSUPPORT_C_TRUE='#'
-  CHIPSUPPORT_C_FALSE=
-fi
-
-
-# Check for support headers
-
-test -f $srcdir/config/$arch/boards/$board/boardsupport.h && \
-
-$as_echo "#define HAVE_BOARDSUPPORT_H 1" >>confdefs.h
-
-
-test -f $srcdir/config/$arch/chips/$chip/chipsupport.h && \
-
-$as_echo "#define HAVE_CHIPSUPPORT_H 1" >>confdefs.h
-
-
-# Test whether we have a calibration file
-
-test -f $srcdir/config/$arch/boards/$board/calibration && \
-    HAVE_CALIBRATION=yes && \
-
-$as_echo "#define HAVE_CALIBRATION 1" >>confdefs.h
-
-
- if test x$HAVE_CALIBRATION == xyes; then
-  CALIBRATION_TRUE=
-  CALIBRATION_FALSE='#'
-else
-  CALIBRATION_TRUE='#'
-  CALIBRATION_FALSE=
-fi
-
-
-# Architecture, board and chip specific CFLAGS and LDFLAGS
-
-# If we pass the --host option, then AC_PROG_CC will select the correct
-# cross-compiler for us.
-
 ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
@@ -15185,12 +15184,6 @@ fi
 
 
 
-# Add in the architecture, board and chip specific CPPFLAGS, CFLAGS and LDFLAGS
-
-CPPFLAGS="$CPPFLAGS $ARCH_CPPFLAGS $CHIP_CPPFLAGS $BOARD_CPPFLAGS"
-CFLAGS="$CFLAGS $ARCH_CFLAGS $CHIP_CFLAGS $BOARD_CFLAGS"
-LDFLAGS="$LDFLAGS $ARCH_CFLAGS $CHIP_CFLAGS $BOARD_CFLAGS"
-
 # Set up testing
 
 if test x"$DEJAGNU" = x
@@ -15222,12 +15215,6 @@ else
   ARC_TRUE='#'
   ARC_FALSE=
 fi
-
-
-# Substitute flags
-
-
-
 
 
 # Substitute DejaGnu variable
@@ -15382,14 +15369,6 @@ fi
 
 if test -z "${MAINTAINER_MODE_TRUE}" && test -z "${MAINTAINER_MODE_FALSE}"; then
   as_fn_error $? "conditional \"MAINTAINER_MODE\" was never defined.
-Usually this means the macro was only invoked conditionally." "$LINENO" 5
-fi
-if test -z "${AMDEP_TRUE}" && test -z "${AMDEP_FALSE}"; then
-  as_fn_error $? "conditional \"AMDEP\" was never defined.
-Usually this means the macro was only invoked conditionally." "$LINENO" 5
-fi
-if test -z "${am__fastdepCC_TRUE}" && test -z "${am__fastdepCC_FALSE}"; then
-  as_fn_error $? "conditional \"am__fastdepCC\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${ENABLED_BENCHMARK_AHA_COMPRESS_TRUE}" && test -z "${ENABLED_BENCHMARK_AHA_COMPRESS_FALSE}"; then
@@ -15718,6 +15697,14 @@ Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${CALIBRATION_TRUE}" && test -z "${CALIBRATION_FALSE}"; then
   as_fn_error $? "conditional \"CALIBRATION\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
+if test -z "${AMDEP_TRUE}" && test -z "${AMDEP_FALSE}"; then
+  as_fn_error $? "conditional \"AMDEP\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
+if test -z "${am__fastdepCC_TRUE}" && test -z "${am__fastdepCC_FALSE}"; then
+  as_fn_error $? "conditional \"am__fastdepCC\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${am__fastdepCC_TRUE}" && test -z "${am__fastdepCC_FALSE}"; then

--- a/configure.ac
+++ b/configure.ac
@@ -38,9 +38,6 @@ AM_INIT_AUTOMAKE([-Wno-portability])
 AM_MAINTAINER_MODE([disable])
 AM_SILENT_RULES([yes])
 
-LT_INIT
-AC_SUBST([LIBTOOL_DEPS])
-
 # List of all benchmarks
 
 bmlist="aha-compress          \
@@ -1299,19 +1296,15 @@ test -f $srcdir/config/$arch/boards/$board/calibration && \
 AM_CONDITIONAL([CALIBRATION], [test x$HAVE_CALIBRATION == xyes])
 
 # Architecture, board and chip specific CFLAGS and LDFLAGS
+CFLAGS="$CFLAGS $ARCH_CFLAGS $CHIP_CFLAGS $BOARD_CFLAGS"
+LDFLAGS="$LDFLAGS $ARCH_LDFLAGS $CHIP_LDFLAGS $BOARD_LDFLAGS"
 
-# If we pass the --host option, then AC_PROG_CC will select the correct
-# cross-compiler for us.
+LT_INIT
+AC_SUBST([LIBTOOL_DEPS])
 
 AC_PROG_CC()
 AM_PROG_AS
 AC_PROG_CC_C99
-
-# Add in the architecture, board and chip specific CPPFLAGS, CFLAGS and LDFLAGS
-
-CPPFLAGS="$CPPFLAGS $ARCH_CPPFLAGS $CHIP_CPPFLAGS $BOARD_CPPFLAGS"
-CFLAGS="$CFLAGS $ARCH_CFLAGS $CHIP_CFLAGS $BOARD_CFLAGS"
-LDFLAGS="$LDFLAGS $ARCH_CFLAGS $CHIP_CFLAGS $BOARD_CFLAGS"
 
 # Set up testing
 
@@ -1335,12 +1328,6 @@ AC_SUBST(BOARD, $board)
 AC_SUBST(CHIP, $chip)
 
 AM_CONDITIONAL([ARC], [test x$arch = xarc])
-
-# Substitute flags
-
-AC_SUBST([CPPFLAGS])
-AC_SUBST([CFLAGS])
-AC_SUBST([LDFLAGS])
 
 # Substitute DejaGnu variable
 

--- a/src/aha-compress/Makefile.am
+++ b/src/aha-compress/Makefile.am
@@ -31,9 +31,8 @@ aha_compress_SOURCES       =
 libaha_compress_la_SOURCES = compress_test.c
 
 aha_compress_LDADD         = $(DUMMY_CRT0) \
-                             $(top_builddir)/support/libmain.la \
-                             libaha-compress.la \
                              $(top_builddir)/support/libsupport.la \
+                             libaha-compress.la \
                              $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 endif

--- a/src/aha-compress/Makefile.in
+++ b/src/aha-compress/Makefile.in
@@ -169,9 +169,8 @@ aha_compress_OBJECTS = $(am_aha_compress_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_AHA_COMPRESS_TRUE@aha_compress_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_AHA_COMPRESS_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_AHA_COMPRESS_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_AHA_COMPRESS_TRUE@	libaha-compress.la \
 @ENABLED_BENCHMARK_AHA_COMPRESS_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_AHA_COMPRESS_TRUE@	libaha-compress.la \
 @ENABLED_BENCHMARK_AHA_COMPRESS_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_AHA_COMPRESS_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_AHA_COMPRESS_TRUE@	$(am__DEPENDENCIES_1)
@@ -384,8 +383,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_AHA_COMPRESS_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_AHA_COMPRESS_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_AHA_COMPRESS_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_AHA_COMPRESS_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -395,9 +392,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_AHA_COMPRESS_TRUE@aha_compress_SOURCES = 
 @ENABLED_BENCHMARK_AHA_COMPRESS_TRUE@libaha_compress_la_SOURCES = compress_test.c
 @ENABLED_BENCHMARK_AHA_COMPRESS_TRUE@aha_compress_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_AHA_COMPRESS_TRUE@                             $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_AHA_COMPRESS_TRUE@                             libaha-compress.la \
 @ENABLED_BENCHMARK_AHA_COMPRESS_TRUE@                             $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_AHA_COMPRESS_TRUE@                             libaha-compress.la \
 @ENABLED_BENCHMARK_AHA_COMPRESS_TRUE@                             $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/aha-mont64/Makefile.am
+++ b/src/aha-mont64/Makefile.am
@@ -33,9 +33,8 @@ aha_mont64_SOURCES       =
 libaha_mont64_la_SOURCES = mont64.c
 
 aha_mont64_LDADD         = $(DUMMY_CRT0) \
-                           $(top_builddir)/support/libmain.la \
-                           libaha-mont64.la \
                            $(top_builddir)/support/libsupport.la \
+                           libaha-mont64.la \
                            $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 endif

--- a/src/aha-mont64/Makefile.in
+++ b/src/aha-mont64/Makefile.in
@@ -170,9 +170,8 @@ aha_mont64_OBJECTS = $(am_aha_mont64_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_AHA_MONT64_TRUE@aha_mont64_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_AHA_MONT64_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_AHA_MONT64_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_AHA_MONT64_TRUE@	libaha-mont64.la \
 @ENABLED_BENCHMARK_AHA_MONT64_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_AHA_MONT64_TRUE@	libaha-mont64.la \
 @ENABLED_BENCHMARK_AHA_MONT64_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_AHA_MONT64_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_AHA_MONT64_TRUE@	$(am__DEPENDENCIES_1)
@@ -385,8 +384,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_AHA_MONT64_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_AHA_MONT64_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_AHA_MONT64_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_AHA_MONT64_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -396,9 +393,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_AHA_MONT64_TRUE@aha_mont64_SOURCES = 
 @ENABLED_BENCHMARK_AHA_MONT64_TRUE@libaha_mont64_la_SOURCES = mont64.c
 @ENABLED_BENCHMARK_AHA_MONT64_TRUE@aha_mont64_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_AHA_MONT64_TRUE@                           $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_AHA_MONT64_TRUE@                           libaha-mont64.la \
 @ENABLED_BENCHMARK_AHA_MONT64_TRUE@                           $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_AHA_MONT64_TRUE@                           libaha-mont64.la \
 @ENABLED_BENCHMARK_AHA_MONT64_TRUE@                           $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/bs/Makefile.am
+++ b/src/bs/Makefile.am
@@ -33,9 +33,8 @@ bs_SOURCES         =
 libbs_la_SOURCES = libbs.c
 
 bs_LDADD           = $(DUMMY_CRT0) \
-                     $(top_builddir)/support/libmain.la \
-                     libbs.la \
                      $(top_builddir)/support/libsupport.la \
+                     libbs.la \
                      $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 endif

--- a/src/bs/Makefile.in
+++ b/src/bs/Makefile.in
@@ -168,10 +168,8 @@ am_bs_OBJECTS =
 bs_OBJECTS = $(am_bs_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_BS_TRUE@bs_DEPENDENCIES = $(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_BS_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_BS_TRUE@	libbs.la \
 @ENABLED_BENCHMARK_BS_TRUE@	$(top_builddir)/support/libsupport.la \
-@ENABLED_BENCHMARK_BS_TRUE@	$(am__DEPENDENCIES_1) \
+@ENABLED_BENCHMARK_BS_TRUE@	libbs.la $(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_BS_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_BS_TRUE@	$(am__DEPENDENCIES_1)
 AM_V_P = $(am__v_P_@AM_V@)
@@ -382,8 +380,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_BS_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_BS_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_BS_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_BS_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -393,9 +389,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_BS_TRUE@bs_SOURCES = 
 @ENABLED_BENCHMARK_BS_TRUE@libbs_la_SOURCES = libbs.c
 @ENABLED_BENCHMARK_BS_TRUE@bs_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_BS_TRUE@                     $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_BS_TRUE@                     libbs.la \
 @ENABLED_BENCHMARK_BS_TRUE@                     $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_BS_TRUE@                     libbs.la \
 @ENABLED_BENCHMARK_BS_TRUE@                     $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/bubblesort/Makefile.am
+++ b/src/bubblesort/Makefile.am
@@ -33,9 +33,8 @@ bubblesort_SOURCES       =
 libbubblesort_la_SOURCES = libbubblesort.c
 
 bubblesort_LDADD         = $(DUMMY_CRT0) \
-                           $(top_builddir)/support/libmain.la \
-                           libbubblesort.la \
                            $(top_builddir)/support/libsupport.la \
+                           libbubblesort.la \
                            $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 endif

--- a/src/bubblesort/Makefile.in
+++ b/src/bubblesort/Makefile.in
@@ -170,9 +170,8 @@ bubblesort_OBJECTS = $(am_bubblesort_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_BUBBLESORT_TRUE@bubblesort_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_BUBBLESORT_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_BUBBLESORT_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_BUBBLESORT_TRUE@	libbubblesort.la \
 @ENABLED_BENCHMARK_BUBBLESORT_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_BUBBLESORT_TRUE@	libbubblesort.la \
 @ENABLED_BENCHMARK_BUBBLESORT_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_BUBBLESORT_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_BUBBLESORT_TRUE@	$(am__DEPENDENCIES_1)
@@ -385,8 +384,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_BUBBLESORT_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_BUBBLESORT_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_BUBBLESORT_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_BUBBLESORT_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -396,9 +393,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_BUBBLESORT_TRUE@bubblesort_SOURCES = 
 @ENABLED_BENCHMARK_BUBBLESORT_TRUE@libbubblesort_la_SOURCES = libbubblesort.c
 @ENABLED_BENCHMARK_BUBBLESORT_TRUE@bubblesort_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_BUBBLESORT_TRUE@                           $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_BUBBLESORT_TRUE@                           libbubblesort.la \
 @ENABLED_BENCHMARK_BUBBLESORT_TRUE@                           $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_BUBBLESORT_TRUE@                           libbubblesort.la \
 @ENABLED_BENCHMARK_BUBBLESORT_TRUE@                           $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/cnt/Makefile.am
+++ b/src/cnt/Makefile.am
@@ -32,9 +32,8 @@ cnt_SOURCES        =
 libcnt_la_SOURCES  = cnt.c
 
 cnt_LDADD          = $(DUMMY_CRT0) \
-                     $(top_builddir)/support/libmain.la \
-                     libcnt.la \
                      $(top_builddir)/support/libsupport.la \
+                     libcnt.la \
                      $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 endif

--- a/src/cnt/Makefile.in
+++ b/src/cnt/Makefile.in
@@ -168,10 +168,8 @@ am_cnt_OBJECTS =
 cnt_OBJECTS = $(am_cnt_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_CNT_TRUE@cnt_DEPENDENCIES = $(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_CNT_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_CNT_TRUE@	libcnt.la \
 @ENABLED_BENCHMARK_CNT_TRUE@	$(top_builddir)/support/libsupport.la \
-@ENABLED_BENCHMARK_CNT_TRUE@	$(am__DEPENDENCIES_1) \
+@ENABLED_BENCHMARK_CNT_TRUE@	libcnt.la $(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_CNT_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_CNT_TRUE@	$(am__DEPENDENCIES_1)
 AM_V_P = $(am__v_P_@AM_V@)
@@ -382,8 +380,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_CNT_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_CNT_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_CNT_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_CNT_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -393,9 +389,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_CNT_TRUE@cnt_SOURCES = 
 @ENABLED_BENCHMARK_CNT_TRUE@libcnt_la_SOURCES = cnt.c
 @ENABLED_BENCHMARK_CNT_TRUE@cnt_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_CNT_TRUE@                     $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_CNT_TRUE@                     libcnt.la \
 @ENABLED_BENCHMARK_CNT_TRUE@                     $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_CNT_TRUE@                     libcnt.la \
 @ENABLED_BENCHMARK_CNT_TRUE@                     $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/common.mk.am
+++ b/src/common.mk.am
@@ -36,8 +36,6 @@ AM_CPPFLAGS = "-DCALIB_SCALE=$(shell $(calib))" \
               -I $(top_srcdir)/config/@ARCH@/boards/@BOARD@ \
               -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
               @CPPFLAGS@
-AM_CFLAGS   = @CFLAGS@
-AM_LDFLAGS  = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in

--- a/src/compress/Makefile.am
+++ b/src/compress/Makefile.am
@@ -40,9 +40,8 @@ compress_SOURCES       =
 libcompress_la_SOURCES = libcompress.c
 
 compress_LDADD         = $(DUMMY_CRT0) \
-                         $(top_builddir)/support/libmain.la \
-                         libcompress.la \
                          $(top_builddir)/support/libsupport.la \
+                         libcompress.la \
                          $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/compress/Makefile.in
+++ b/src/compress/Makefile.in
@@ -177,9 +177,8 @@ compress_OBJECTS = $(am_compress_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_COMPRESS_TRUE@compress_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_COMPRESS_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_COMPRESS_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_COMPRESS_TRUE@	libcompress.la \
 @ENABLED_BENCHMARK_COMPRESS_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_COMPRESS_TRUE@	libcompress.la \
 @ENABLED_BENCHMARK_COMPRESS_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_COMPRESS_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_COMPRESS_TRUE@	$(am__DEPENDENCIES_1)
@@ -391,8 +390,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_COMPRESS_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_COMPRESS_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_COMPRESS_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_COMPRESS_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -402,9 +399,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_COMPRESS_TRUE@compress_SOURCES = 
 @ENABLED_BENCHMARK_COMPRESS_TRUE@libcompress_la_SOURCES = libcompress.c
 @ENABLED_BENCHMARK_COMPRESS_TRUE@compress_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_COMPRESS_TRUE@                         $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_COMPRESS_TRUE@                         libcompress.la \
 @ENABLED_BENCHMARK_COMPRESS_TRUE@                         $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_COMPRESS_TRUE@                         libcompress.la \
 @ENABLED_BENCHMARK_COMPRESS_TRUE@                         $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/cover/Makefile.am
+++ b/src/cover/Makefile.am
@@ -32,9 +32,8 @@ cover_SOURCES       =
 libcover_la_SOURCES = libcover.c
 
 cover_LDADD         = $(DUMMY_CRT0) \
-                      $(top_builddir)/support/libmain.la \
-                      libcover.la \
                       $(top_builddir)/support/libsupport.la \
+                      libcover.la \
                       $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/cover/Makefile.in
+++ b/src/cover/Makefile.in
@@ -169,9 +169,8 @@ cover_OBJECTS = $(am_cover_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_COVER_TRUE@cover_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_COVER_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_COVER_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_COVER_TRUE@	libcover.la \
 @ENABLED_BENCHMARK_COVER_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_COVER_TRUE@	libcover.la \
 @ENABLED_BENCHMARK_COVER_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_COVER_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_COVER_TRUE@	$(am__DEPENDENCIES_1)
@@ -383,8 +382,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_COVER_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_COVER_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_COVER_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_COVER_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -394,9 +391,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_COVER_TRUE@cover_SOURCES = 
 @ENABLED_BENCHMARK_COVER_TRUE@libcover_la_SOURCES = libcover.c
 @ENABLED_BENCHMARK_COVER_TRUE@cover_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_COVER_TRUE@                      $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_COVER_TRUE@                      libcover.la \
 @ENABLED_BENCHMARK_COVER_TRUE@                      $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_COVER_TRUE@                      libcover.la \
 @ENABLED_BENCHMARK_COVER_TRUE@                      $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/crc/Makefile.am
+++ b/src/crc/Makefile.am
@@ -32,9 +32,8 @@ crc_SOURCES        =
 libcrc_la_SOURCES = libcrc.c
 
 crc_LDADD          = $(DUMMY_CRT0) \
-                     $(top_builddir)/support/libmain.la \
-                     libcrc.la \
                      $(top_builddir)/support/libsupport.la \
+                     libcrc.la \
                      $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/crc/Makefile.in
+++ b/src/crc/Makefile.in
@@ -168,10 +168,8 @@ am_crc_OBJECTS =
 crc_OBJECTS = $(am_crc_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_CRC_TRUE@crc_DEPENDENCIES = $(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_CRC_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_CRC_TRUE@	libcrc.la \
 @ENABLED_BENCHMARK_CRC_TRUE@	$(top_builddir)/support/libsupport.la \
-@ENABLED_BENCHMARK_CRC_TRUE@	$(am__DEPENDENCIES_1) \
+@ENABLED_BENCHMARK_CRC_TRUE@	libcrc.la $(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_CRC_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_CRC_TRUE@	$(am__DEPENDENCIES_1)
 AM_V_P = $(am__v_P_@AM_V@)
@@ -382,8 +380,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_CRC_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_CRC_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_CRC_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_CRC_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -393,9 +389,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_CRC_TRUE@crc_SOURCES = 
 @ENABLED_BENCHMARK_CRC_TRUE@libcrc_la_SOURCES = libcrc.c
 @ENABLED_BENCHMARK_CRC_TRUE@crc_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_CRC_TRUE@                     $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_CRC_TRUE@                     libcrc.la \
 @ENABLED_BENCHMARK_CRC_TRUE@                     $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_CRC_TRUE@                     libcrc.la \
 @ENABLED_BENCHMARK_CRC_TRUE@                     $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/crc32/Makefile.am
+++ b/src/crc32/Makefile.am
@@ -33,9 +33,8 @@ crc32_SOURCES       =
 libcrc32_la_SOURCES = crc_32.c
 
 crc32_LDADD         = $(DUMMY_CRT0) \
-                      $(top_builddir)/support/libmain.la \
-                      libcrc32.la \
                       $(top_builddir)/support/libsupport.la \
+                      libcrc32.la \
                       $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 endif

--- a/src/crc32/Makefile.in
+++ b/src/crc32/Makefile.in
@@ -169,9 +169,8 @@ crc32_OBJECTS = $(am_crc32_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_CRC32_TRUE@crc32_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_CRC32_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_CRC32_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_CRC32_TRUE@	libcrc32.la \
 @ENABLED_BENCHMARK_CRC32_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_CRC32_TRUE@	libcrc32.la \
 @ENABLED_BENCHMARK_CRC32_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_CRC32_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_CRC32_TRUE@	$(am__DEPENDENCIES_1)
@@ -383,8 +382,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_CRC32_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_CRC32_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_CRC32_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_CRC32_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -394,9 +391,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_CRC32_TRUE@crc32_SOURCES = 
 @ENABLED_BENCHMARK_CRC32_TRUE@libcrc32_la_SOURCES = crc_32.c
 @ENABLED_BENCHMARK_CRC32_TRUE@crc32_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_CRC32_TRUE@                      $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_CRC32_TRUE@                      libcrc32.la \
 @ENABLED_BENCHMARK_CRC32_TRUE@                      $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_CRC32_TRUE@                      libcrc32.la \
 @ENABLED_BENCHMARK_CRC32_TRUE@                      $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/ctl-stack/Makefile.am
+++ b/src/ctl-stack/Makefile.am
@@ -33,9 +33,8 @@ ctl_stack_SOURCES       =
 libctl_stack_la_SOURCES  = ctl.c ctl.h stack.h
 
 ctl_stack_LDADD         = $(DUMMY_CRT0) \
-                          $(top_builddir)/support/libmain.la \
-                          libctl-stack.la \
                           $(top_builddir)/support/libsupport.la \
+                          libctl-stack.la \
                           $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 libctl_stack_la_CPPFLAGS = -DCTL_STACK ${AM_CPPFLAGS}
 

--- a/src/ctl-stack/Makefile.in
+++ b/src/ctl-stack/Makefile.in
@@ -170,9 +170,8 @@ ctl_stack_OBJECTS = $(am_ctl_stack_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_CTL_STACK_TRUE@ctl_stack_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_CTL_STACK_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_CTL_STACK_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_CTL_STACK_TRUE@	libctl-stack.la \
 @ENABLED_BENCHMARK_CTL_STACK_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_CTL_STACK_TRUE@	libctl-stack.la \
 @ENABLED_BENCHMARK_CTL_STACK_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_CTL_STACK_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_CTL_STACK_TRUE@	$(am__DEPENDENCIES_1)
@@ -385,8 +384,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_CTL_STACK_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_CTL_STACK_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_CTL_STACK_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_CTL_STACK_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -396,9 +393,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_CTL_STACK_TRUE@ctl_stack_SOURCES = 
 @ENABLED_BENCHMARK_CTL_STACK_TRUE@libctl_stack_la_SOURCES = ctl.c ctl.h stack.h
 @ENABLED_BENCHMARK_CTL_STACK_TRUE@ctl_stack_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_CTL_STACK_TRUE@                          $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_CTL_STACK_TRUE@                          libctl-stack.la \
 @ENABLED_BENCHMARK_CTL_STACK_TRUE@                          $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_CTL_STACK_TRUE@                          libctl-stack.la \
 @ENABLED_BENCHMARK_CTL_STACK_TRUE@                          $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 @ENABLED_BENCHMARK_CTL_STACK_TRUE@libctl_stack_la_CPPFLAGS = -DCTL_STACK ${AM_CPPFLAGS}

--- a/src/ctl-string/Makefile.am
+++ b/src/ctl-string/Makefile.am
@@ -32,9 +32,8 @@ ctl_string_SOURCES       =
 libctl_string_la_SOURCES = string.c
 
 ctl_string_LDADD         = $(DUMMY_CRT0) \
-                           $(top_builddir)/support/libmain.la \
-                           libctl-string.la \
                            $(top_builddir)/support/libsupport.la \
+                           libctl-string.la \
                            $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 endif

--- a/src/ctl-string/Makefile.in
+++ b/src/ctl-string/Makefile.in
@@ -170,9 +170,8 @@ ctl_string_OBJECTS = $(am_ctl_string_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_CTL_STRING_TRUE@ctl_string_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_CTL_STRING_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_CTL_STRING_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_CTL_STRING_TRUE@	libctl-string.la \
 @ENABLED_BENCHMARK_CTL_STRING_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_CTL_STRING_TRUE@	libctl-string.la \
 @ENABLED_BENCHMARK_CTL_STRING_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_CTL_STRING_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_CTL_STRING_TRUE@	$(am__DEPENDENCIES_1)
@@ -385,8 +384,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_CTL_STRING_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_CTL_STRING_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_CTL_STRING_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_CTL_STRING_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -396,9 +393,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_CTL_STRING_TRUE@ctl_string_SOURCES = 
 @ENABLED_BENCHMARK_CTL_STRING_TRUE@libctl_string_la_SOURCES = string.c
 @ENABLED_BENCHMARK_CTL_STRING_TRUE@ctl_string_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_CTL_STRING_TRUE@                           $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_CTL_STRING_TRUE@                           libctl-string.la \
 @ENABLED_BENCHMARK_CTL_STRING_TRUE@                           $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_CTL_STRING_TRUE@                           libctl-string.la \
 @ENABLED_BENCHMARK_CTL_STRING_TRUE@                           $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/ctl-vector/Makefile.am
+++ b/src/ctl-vector/Makefile.am
@@ -33,9 +33,8 @@ ctl_vector_SOURCES        =
 libctl_vector_la_SOURCES  = ctl.c ctl.h vector.h
 
 ctl_vector_LDADD          = $(DUMMY_CRT0) \
-                            $(top_builddir)/support/libmain.la \
-                            libctl-vector.la \
                             $(top_builddir)/support/libsupport.la \
+                            libctl-vector.la \
                             $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 libctl_vector_la_CPPFLAGS = -DCTL_VECTOR ${AM_CPPFLAGS}
 

--- a/src/ctl-vector/Makefile.in
+++ b/src/ctl-vector/Makefile.in
@@ -170,9 +170,8 @@ ctl_vector_OBJECTS = $(am_ctl_vector_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_CTL_VECTOR_TRUE@ctl_vector_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_CTL_VECTOR_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_CTL_VECTOR_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_CTL_VECTOR_TRUE@	libctl-vector.la \
 @ENABLED_BENCHMARK_CTL_VECTOR_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_CTL_VECTOR_TRUE@	libctl-vector.la \
 @ENABLED_BENCHMARK_CTL_VECTOR_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_CTL_VECTOR_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_CTL_VECTOR_TRUE@	$(am__DEPENDENCIES_1)
@@ -385,8 +384,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_CTL_VECTOR_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_CTL_VECTOR_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_CTL_VECTOR_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_CTL_VECTOR_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -396,9 +393,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_CTL_VECTOR_TRUE@ctl_vector_SOURCES = 
 @ENABLED_BENCHMARK_CTL_VECTOR_TRUE@libctl_vector_la_SOURCES = ctl.c ctl.h vector.h
 @ENABLED_BENCHMARK_CTL_VECTOR_TRUE@ctl_vector_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_CTL_VECTOR_TRUE@                            $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_CTL_VECTOR_TRUE@                            libctl-vector.la \
 @ENABLED_BENCHMARK_CTL_VECTOR_TRUE@                            $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_CTL_VECTOR_TRUE@                            libctl-vector.la \
 @ENABLED_BENCHMARK_CTL_VECTOR_TRUE@                            $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 @ENABLED_BENCHMARK_CTL_VECTOR_TRUE@libctl_vector_la_CPPFLAGS = -DCTL_VECTOR ${AM_CPPFLAGS}

--- a/src/cubic/Makefile.am
+++ b/src/cubic/Makefile.am
@@ -33,9 +33,8 @@ cubic_SOURCES       =
 libcubic_la_SOURCES = libcubic.c basicmath_small.c pi.h snipmath.h sniptype.h
 
 cubic_LDADD         = $(DUMMY_CRT0) \
-                      $(top_builddir)/support/libmain.la \
-                      libcubic.la \
                       $(top_builddir)/support/libsupport.la \
+                      libcubic.la \
                       $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT) \
                       $(LIBM)
 endif

--- a/src/cubic/Makefile.in
+++ b/src/cubic/Makefile.in
@@ -171,9 +171,8 @@ cubic_OBJECTS = $(am_cubic_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_CUBIC_TRUE@cubic_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_CUBIC_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_CUBIC_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_CUBIC_TRUE@	libcubic.la \
 @ENABLED_BENCHMARK_CUBIC_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_CUBIC_TRUE@	libcubic.la \
 @ENABLED_BENCHMARK_CUBIC_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_CUBIC_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_CUBIC_TRUE@	$(am__DEPENDENCIES_1) $(LIBM)
@@ -385,8 +384,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_CUBIC_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_CUBIC_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_CUBIC_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_CUBIC_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -396,9 +393,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_CUBIC_TRUE@cubic_SOURCES = 
 @ENABLED_BENCHMARK_CUBIC_TRUE@libcubic_la_SOURCES = libcubic.c basicmath_small.c pi.h snipmath.h sniptype.h
 @ENABLED_BENCHMARK_CUBIC_TRUE@cubic_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_CUBIC_TRUE@                      $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_CUBIC_TRUE@                      libcubic.la \
 @ENABLED_BENCHMARK_CUBIC_TRUE@                      $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_CUBIC_TRUE@                      libcubic.la \
 @ENABLED_BENCHMARK_CUBIC_TRUE@                      $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT) \
 @ENABLED_BENCHMARK_CUBIC_TRUE@                      $(LIBM)
 

--- a/src/dijkstra/Makefile.am
+++ b/src/dijkstra/Makefile.am
@@ -32,9 +32,8 @@ dijkstra_SOURCES       =
 libdijkstra_la_SOURCES = dijkstra_small.c
 
 dijkstra_LDADD         = $(DUMMY_CRT0) \
-                         $(top_builddir)/support/libmain.la \
-                         libdijkstra.la \
                          $(top_builddir)/support/libsupport.la \
+                         libdijkstra.la \
                          $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/dijkstra/Makefile.in
+++ b/src/dijkstra/Makefile.in
@@ -170,9 +170,8 @@ dijkstra_OBJECTS = $(am_dijkstra_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_DIJKSTRA_TRUE@dijkstra_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_DIJKSTRA_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_DIJKSTRA_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_DIJKSTRA_TRUE@	libdijkstra.la \
 @ENABLED_BENCHMARK_DIJKSTRA_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_DIJKSTRA_TRUE@	libdijkstra.la \
 @ENABLED_BENCHMARK_DIJKSTRA_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_DIJKSTRA_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_DIJKSTRA_TRUE@	$(am__DEPENDENCIES_1)
@@ -384,8 +383,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_DIJKSTRA_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_DIJKSTRA_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_DIJKSTRA_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_DIJKSTRA_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -395,9 +392,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_DIJKSTRA_TRUE@dijkstra_SOURCES = 
 @ENABLED_BENCHMARK_DIJKSTRA_TRUE@libdijkstra_la_SOURCES = dijkstra_small.c
 @ENABLED_BENCHMARK_DIJKSTRA_TRUE@dijkstra_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_DIJKSTRA_TRUE@                         $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_DIJKSTRA_TRUE@                         libdijkstra.la \
 @ENABLED_BENCHMARK_DIJKSTRA_TRUE@                         $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_DIJKSTRA_TRUE@                         libdijkstra.la \
 @ENABLED_BENCHMARK_DIJKSTRA_TRUE@                         $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/dtoa/Makefile.am
+++ b/src/dtoa/Makefile.am
@@ -32,9 +32,8 @@ dtoa_SOURCES       =
 libdtoa_la_SOURCES = libdtoa.c
 
 dtoa_LDADD         = $(DUMMY_CRT0) \
-                     $(top_builddir)/support/libmain.la \
-                     libdtoa.la \
                      $(top_builddir)/support/libsupport.la \
+                     libdtoa.la \
                      $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/dtoa/Makefile.in
+++ b/src/dtoa/Makefile.in
@@ -169,10 +169,8 @@ dtoa_OBJECTS = $(am_dtoa_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_DTOA_TRUE@dtoa_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_DTOA_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_DTOA_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_DTOA_TRUE@	libdtoa.la \
 @ENABLED_BENCHMARK_DTOA_TRUE@	$(top_builddir)/support/libsupport.la \
-@ENABLED_BENCHMARK_DTOA_TRUE@	$(am__DEPENDENCIES_1) \
+@ENABLED_BENCHMARK_DTOA_TRUE@	libdtoa.la $(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_DTOA_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_DTOA_TRUE@	$(am__DEPENDENCIES_1)
 AM_V_P = $(am__v_P_@AM_V@)
@@ -383,8 +381,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_DTOA_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_DTOA_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_DTOA_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_DTOA_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -394,9 +390,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_DTOA_TRUE@dtoa_SOURCES = 
 @ENABLED_BENCHMARK_DTOA_TRUE@libdtoa_la_SOURCES = libdtoa.c
 @ENABLED_BENCHMARK_DTOA_TRUE@dtoa_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_DTOA_TRUE@                     $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_DTOA_TRUE@                     libdtoa.la \
 @ENABLED_BENCHMARK_DTOA_TRUE@                     $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_DTOA_TRUE@                     libdtoa.la \
 @ENABLED_BENCHMARK_DTOA_TRUE@                     $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/duff/Makefile.am
+++ b/src/duff/Makefile.am
@@ -32,9 +32,8 @@ duff_SOURCES       =
 libduff_la_SOURCES = libduff.c
 
 duff_LDADD         = $(DUMMY_CRT0) \
-                     $(top_builddir)/support/libmain.la \
-                     libduff.la \
                      $(top_builddir)/support/libsupport.la \
+                     libduff.la \
                      $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/duff/Makefile.in
+++ b/src/duff/Makefile.in
@@ -169,10 +169,8 @@ duff_OBJECTS = $(am_duff_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_DUFF_TRUE@duff_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_DUFF_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_DUFF_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_DUFF_TRUE@	libduff.la \
 @ENABLED_BENCHMARK_DUFF_TRUE@	$(top_builddir)/support/libsupport.la \
-@ENABLED_BENCHMARK_DUFF_TRUE@	$(am__DEPENDENCIES_1) \
+@ENABLED_BENCHMARK_DUFF_TRUE@	libduff.la $(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_DUFF_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_DUFF_TRUE@	$(am__DEPENDENCIES_1)
 AM_V_P = $(am__v_P_@AM_V@)
@@ -383,8 +381,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_DUFF_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_DUFF_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_DUFF_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_DUFF_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -394,9 +390,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_DUFF_TRUE@duff_SOURCES = 
 @ENABLED_BENCHMARK_DUFF_TRUE@libduff_la_SOURCES = libduff.c
 @ENABLED_BENCHMARK_DUFF_TRUE@duff_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_DUFF_TRUE@                     $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_DUFF_TRUE@                     libduff.la \
 @ENABLED_BENCHMARK_DUFF_TRUE@                     $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_DUFF_TRUE@                     libduff.la \
 @ENABLED_BENCHMARK_DUFF_TRUE@                     $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/edn/Makefile.am
+++ b/src/edn/Makefile.am
@@ -32,9 +32,8 @@ edn_SOURCES        =
 libedn_la_SOURCES = libedn.c
 
 edn_LDADD          = $(DUMMY_CRT0) \
-                     $(top_builddir)/support/libmain.la \
-                     libedn.la \
                      $(top_builddir)/support/libsupport.la \
+                     libedn.la \
                      $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/edn/Makefile.in
+++ b/src/edn/Makefile.in
@@ -168,10 +168,8 @@ am_edn_OBJECTS =
 edn_OBJECTS = $(am_edn_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_EDN_TRUE@edn_DEPENDENCIES = $(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_EDN_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_EDN_TRUE@	libedn.la \
 @ENABLED_BENCHMARK_EDN_TRUE@	$(top_builddir)/support/libsupport.la \
-@ENABLED_BENCHMARK_EDN_TRUE@	$(am__DEPENDENCIES_1) \
+@ENABLED_BENCHMARK_EDN_TRUE@	libedn.la $(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_EDN_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_EDN_TRUE@	$(am__DEPENDENCIES_1)
 AM_V_P = $(am__v_P_@AM_V@)
@@ -382,8 +380,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_EDN_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_EDN_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_EDN_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_EDN_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -393,9 +389,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_EDN_TRUE@edn_SOURCES = 
 @ENABLED_BENCHMARK_EDN_TRUE@libedn_la_SOURCES = libedn.c
 @ENABLED_BENCHMARK_EDN_TRUE@edn_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_EDN_TRUE@                     $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_EDN_TRUE@                     libedn.la \
 @ENABLED_BENCHMARK_EDN_TRUE@                     $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_EDN_TRUE@                     libedn.la \
 @ENABLED_BENCHMARK_EDN_TRUE@                     $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/expint/Makefile.am
+++ b/src/expint/Makefile.am
@@ -32,9 +32,8 @@ expint_SOURCES       =
 libexpint_la_SOURCES = libexpint.c
 
 expint_LDADD         = $(DUMMY_CRT0) \
-                       $(top_builddir)/support/libmain.la \
-                       libexpint.la \
                        $(top_builddir)/support/libsupport.la \
+                       libexpint.la \
                        $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/expint/Makefile.in
+++ b/src/expint/Makefile.in
@@ -169,9 +169,8 @@ expint_OBJECTS = $(am_expint_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_EXPINT_TRUE@expint_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_EXPINT_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_EXPINT_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_EXPINT_TRUE@	libexpint.la \
 @ENABLED_BENCHMARK_EXPINT_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_EXPINT_TRUE@	libexpint.la \
 @ENABLED_BENCHMARK_EXPINT_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_EXPINT_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_EXPINT_TRUE@	$(am__DEPENDENCIES_1)
@@ -383,8 +382,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_EXPINT_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_EXPINT_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_EXPINT_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_EXPINT_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -394,9 +391,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_EXPINT_TRUE@expint_SOURCES = 
 @ENABLED_BENCHMARK_EXPINT_TRUE@libexpint_la_SOURCES = libexpint.c
 @ENABLED_BENCHMARK_EXPINT_TRUE@expint_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_EXPINT_TRUE@                       $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_EXPINT_TRUE@                       libexpint.la \
 @ENABLED_BENCHMARK_EXPINT_TRUE@                       $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_EXPINT_TRUE@                       libexpint.la \
 @ENABLED_BENCHMARK_EXPINT_TRUE@                       $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/fac/Makefile.am
+++ b/src/fac/Makefile.am
@@ -32,9 +32,8 @@ fac_SOURCES        =
 libfac_la_SOURCES = libfac.c
 
 fac_LDADD          = $(DUMMY_CRT0) \
-                     $(top_builddir)/support/libmain.la \
-                     libfac.la \
                      $(top_builddir)/support/libsupport.la \
+                     libfac.la \
                      $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/fac/Makefile.in
+++ b/src/fac/Makefile.in
@@ -168,10 +168,8 @@ am_fac_OBJECTS =
 fac_OBJECTS = $(am_fac_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_FAC_TRUE@fac_DEPENDENCIES = $(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_FAC_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_FAC_TRUE@	libfac.la \
 @ENABLED_BENCHMARK_FAC_TRUE@	$(top_builddir)/support/libsupport.la \
-@ENABLED_BENCHMARK_FAC_TRUE@	$(am__DEPENDENCIES_1) \
+@ENABLED_BENCHMARK_FAC_TRUE@	libfac.la $(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_FAC_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_FAC_TRUE@	$(am__DEPENDENCIES_1)
 AM_V_P = $(am__v_P_@AM_V@)
@@ -382,8 +380,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_FAC_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_FAC_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_FAC_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_FAC_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -393,9 +389,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_FAC_TRUE@fac_SOURCES = 
 @ENABLED_BENCHMARK_FAC_TRUE@libfac_la_SOURCES = libfac.c
 @ENABLED_BENCHMARK_FAC_TRUE@fac_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_FAC_TRUE@                     $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_FAC_TRUE@                     libfac.la \
 @ENABLED_BENCHMARK_FAC_TRUE@                     $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_FAC_TRUE@                     libfac.la \
 @ENABLED_BENCHMARK_FAC_TRUE@                     $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/fasta/Makefile.am
+++ b/src/fasta/Makefile.am
@@ -32,9 +32,8 @@ fasta_SOURCES       =
 libfasta_la_SOURCES = libfasta.c
 
 fasta_LDADD         = $(DUMMY_CRT0) \
-                      $(top_builddir)/support/libmain.la \
-                      libfasta.la \
                       $(top_builddir)/support/libsupport.la \
+                      libfasta.la \
                       $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/fasta/Makefile.in
+++ b/src/fasta/Makefile.in
@@ -169,9 +169,8 @@ fasta_OBJECTS = $(am_fasta_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_FASTA_TRUE@fasta_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_FASTA_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_FASTA_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_FASTA_TRUE@	libfasta.la \
 @ENABLED_BENCHMARK_FASTA_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_FASTA_TRUE@	libfasta.la \
 @ENABLED_BENCHMARK_FASTA_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_FASTA_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_FASTA_TRUE@	$(am__DEPENDENCIES_1)
@@ -383,8 +382,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_FASTA_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_FASTA_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_FASTA_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_FASTA_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -394,9 +391,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_FASTA_TRUE@fasta_SOURCES = 
 @ENABLED_BENCHMARK_FASTA_TRUE@libfasta_la_SOURCES = libfasta.c
 @ENABLED_BENCHMARK_FASTA_TRUE@fasta_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_FASTA_TRUE@                      $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_FASTA_TRUE@                      libfasta.la \
 @ENABLED_BENCHMARK_FASTA_TRUE@                      $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_FASTA_TRUE@                      libfasta.la \
 @ENABLED_BENCHMARK_FASTA_TRUE@                      $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/fdct/Makefile.am
+++ b/src/fdct/Makefile.am
@@ -32,9 +32,8 @@ fdct_SOURCES       =
 libfdct_la_SOURCES = libfdct.c
 
 fdct_LDADD         = $(DUMMY_CRT0) \
-                     $(top_builddir)/support/libmain.la \
-                     libfdct.la \
                      $(top_builddir)/support/libsupport.la \
+                     libfdct.la \
                      $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/fdct/Makefile.in
+++ b/src/fdct/Makefile.in
@@ -169,10 +169,8 @@ fdct_OBJECTS = $(am_fdct_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_FDCT_TRUE@fdct_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_FDCT_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_FDCT_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_FDCT_TRUE@	libfdct.la \
 @ENABLED_BENCHMARK_FDCT_TRUE@	$(top_builddir)/support/libsupport.la \
-@ENABLED_BENCHMARK_FDCT_TRUE@	$(am__DEPENDENCIES_1) \
+@ENABLED_BENCHMARK_FDCT_TRUE@	libfdct.la $(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_FDCT_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_FDCT_TRUE@	$(am__DEPENDENCIES_1)
 AM_V_P = $(am__v_P_@AM_V@)
@@ -383,8 +381,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_FDCT_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_FDCT_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_FDCT_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_FDCT_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -394,9 +390,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_FDCT_TRUE@fdct_SOURCES = 
 @ENABLED_BENCHMARK_FDCT_TRUE@libfdct_la_SOURCES = libfdct.c
 @ENABLED_BENCHMARK_FDCT_TRUE@fdct_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_FDCT_TRUE@                     $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_FDCT_TRUE@                     libfdct.la \
 @ENABLED_BENCHMARK_FDCT_TRUE@                     $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_FDCT_TRUE@                     libfdct.la \
 @ENABLED_BENCHMARK_FDCT_TRUE@                     $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/fibcall/Makefile.am
+++ b/src/fibcall/Makefile.am
@@ -32,9 +32,8 @@ fibcall_SOURCES       =
 libfibcall_la_SOURCES = libfibcall.c
 
 fibcall_LDADD         = $(DUMMY_CRT0) \
-                        $(top_builddir)/support/libmain.la \
-                        libfibcall.la \
                         $(top_builddir)/support/libsupport.la \
+                        libfibcall.la \
                         $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/fibcall/Makefile.in
+++ b/src/fibcall/Makefile.in
@@ -170,9 +170,8 @@ fibcall_OBJECTS = $(am_fibcall_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_FIBCALL_TRUE@fibcall_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_FIBCALL_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_FIBCALL_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_FIBCALL_TRUE@	libfibcall.la \
 @ENABLED_BENCHMARK_FIBCALL_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_FIBCALL_TRUE@	libfibcall.la \
 @ENABLED_BENCHMARK_FIBCALL_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_FIBCALL_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_FIBCALL_TRUE@	$(am__DEPENDENCIES_1)
@@ -384,8 +383,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_FIBCALL_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_FIBCALL_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_FIBCALL_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_FIBCALL_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -395,9 +392,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_FIBCALL_TRUE@fibcall_SOURCES = 
 @ENABLED_BENCHMARK_FIBCALL_TRUE@libfibcall_la_SOURCES = libfibcall.c
 @ENABLED_BENCHMARK_FIBCALL_TRUE@fibcall_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_FIBCALL_TRUE@                        $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_FIBCALL_TRUE@                        libfibcall.la \
 @ENABLED_BENCHMARK_FIBCALL_TRUE@                        $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_FIBCALL_TRUE@                        libfibcall.la \
 @ENABLED_BENCHMARK_FIBCALL_TRUE@                        $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/fir/Makefile.am
+++ b/src/fir/Makefile.am
@@ -32,9 +32,8 @@ fir_SOURCES        =
 libfir_la_SOURCES = libfir.c
 
 fir_LDADD          = $(DUMMY_CRT0) \
-                     $(top_builddir)/support/libmain.la \
-                     libfir.la \
                      $(top_builddir)/support/libsupport.la \
+                     libfir.la \
                      $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/fir/Makefile.in
+++ b/src/fir/Makefile.in
@@ -168,10 +168,8 @@ am_fir_OBJECTS =
 fir_OBJECTS = $(am_fir_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_FIR_TRUE@fir_DEPENDENCIES = $(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_FIR_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_FIR_TRUE@	libfir.la \
 @ENABLED_BENCHMARK_FIR_TRUE@	$(top_builddir)/support/libsupport.la \
-@ENABLED_BENCHMARK_FIR_TRUE@	$(am__DEPENDENCIES_1) \
+@ENABLED_BENCHMARK_FIR_TRUE@	libfir.la $(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_FIR_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_FIR_TRUE@	$(am__DEPENDENCIES_1)
 AM_V_P = $(am__v_P_@AM_V@)
@@ -382,8 +380,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_FIR_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_FIR_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_FIR_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_FIR_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -393,9 +389,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_FIR_TRUE@fir_SOURCES = 
 @ENABLED_BENCHMARK_FIR_TRUE@libfir_la_SOURCES = libfir.c
 @ENABLED_BENCHMARK_FIR_TRUE@fir_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_FIR_TRUE@                     $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_FIR_TRUE@                     libfir.la \
 @ENABLED_BENCHMARK_FIR_TRUE@                     $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_FIR_TRUE@                     libfir.la \
 @ENABLED_BENCHMARK_FIR_TRUE@                     $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/frac/Makefile.am
+++ b/src/frac/Makefile.am
@@ -32,9 +32,8 @@ frac_SOURCES       =
 libfrac_la_SOURCES = libfrac.c
 
 frac_LDADD         = $(DUMMY_CRT0) \
-                     $(top_builddir)/support/libmain.la \
-                     libfrac.la \
                      $(top_builddir)/support/libsupport.la \
+                     libfrac.la \
                      $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/frac/Makefile.in
+++ b/src/frac/Makefile.in
@@ -169,10 +169,8 @@ frac_OBJECTS = $(am_frac_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_FRAC_TRUE@frac_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_FRAC_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_FRAC_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_FRAC_TRUE@	libfrac.la \
 @ENABLED_BENCHMARK_FRAC_TRUE@	$(top_builddir)/support/libsupport.la \
-@ENABLED_BENCHMARK_FRAC_TRUE@	$(am__DEPENDENCIES_1) \
+@ENABLED_BENCHMARK_FRAC_TRUE@	libfrac.la $(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_FRAC_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_FRAC_TRUE@	$(am__DEPENDENCIES_1)
 AM_V_P = $(am__v_P_@AM_V@)
@@ -383,8 +381,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_FRAC_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_FRAC_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_FRAC_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_FRAC_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -394,9 +390,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_FRAC_TRUE@frac_SOURCES = 
 @ENABLED_BENCHMARK_FRAC_TRUE@libfrac_la_SOURCES = libfrac.c
 @ENABLED_BENCHMARK_FRAC_TRUE@frac_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_FRAC_TRUE@                     $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_FRAC_TRUE@                     libfrac.la \
 @ENABLED_BENCHMARK_FRAC_TRUE@                     $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_FRAC_TRUE@                     libfrac.la \
 @ENABLED_BENCHMARK_FRAC_TRUE@                     $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/huffbench/Makefile.am
+++ b/src/huffbench/Makefile.am
@@ -32,9 +32,8 @@ huffbench_SOURCES       =
 libhuffbench_la_SOURCES = libhuffbench.c
 
 huffbench_LDADD         = $(DUMMY_CRT0) \
-                          $(top_builddir)/support/libmain.la \
-                          libhuffbench.la \
                           $(top_builddir)/support/libsupport.la \
+                          libhuffbench.la \
                           $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/huffbench/Makefile.in
+++ b/src/huffbench/Makefile.in
@@ -170,9 +170,8 @@ huffbench_OBJECTS = $(am_huffbench_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_HUFFBENCH_TRUE@huffbench_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_HUFFBENCH_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_HUFFBENCH_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_HUFFBENCH_TRUE@	libhuffbench.la \
 @ENABLED_BENCHMARK_HUFFBENCH_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_HUFFBENCH_TRUE@	libhuffbench.la \
 @ENABLED_BENCHMARK_HUFFBENCH_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_HUFFBENCH_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_HUFFBENCH_TRUE@	$(am__DEPENDENCIES_1)
@@ -385,8 +384,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_HUFFBENCH_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_HUFFBENCH_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_HUFFBENCH_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_HUFFBENCH_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -396,9 +393,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_HUFFBENCH_TRUE@huffbench_SOURCES = 
 @ENABLED_BENCHMARK_HUFFBENCH_TRUE@libhuffbench_la_SOURCES = libhuffbench.c
 @ENABLED_BENCHMARK_HUFFBENCH_TRUE@huffbench_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_HUFFBENCH_TRUE@                          $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_HUFFBENCH_TRUE@                          libhuffbench.la \
 @ENABLED_BENCHMARK_HUFFBENCH_TRUE@                          $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_HUFFBENCH_TRUE@                          libhuffbench.la \
 @ENABLED_BENCHMARK_HUFFBENCH_TRUE@                          $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/insertsort/Makefile.am
+++ b/src/insertsort/Makefile.am
@@ -32,9 +32,8 @@ insertsort_SOURCES       =
 libinsertsort_la_SOURCES = libinsertsort.c
 
 insertsort_LDADD         = $(DUMMY_CRT0) \
-                           $(top_builddir)/support/libmain.la \
-                           libinsertsort.la \
                            $(top_builddir)/support/libsupport.la \
+                           libinsertsort.la \
                            $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/insertsort/Makefile.in
+++ b/src/insertsort/Makefile.in
@@ -170,9 +170,8 @@ insertsort_OBJECTS = $(am_insertsort_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_INSERTSORT_TRUE@insertsort_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_INSERTSORT_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_INSERTSORT_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_INSERTSORT_TRUE@	libinsertsort.la \
 @ENABLED_BENCHMARK_INSERTSORT_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_INSERTSORT_TRUE@	libinsertsort.la \
 @ENABLED_BENCHMARK_INSERTSORT_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_INSERTSORT_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_INSERTSORT_TRUE@	$(am__DEPENDENCIES_1)
@@ -385,8 +384,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_INSERTSORT_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_INSERTSORT_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_INSERTSORT_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_INSERTSORT_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -396,9 +393,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_INSERTSORT_TRUE@insertsort_SOURCES = 
 @ENABLED_BENCHMARK_INSERTSORT_TRUE@libinsertsort_la_SOURCES = libinsertsort.c
 @ENABLED_BENCHMARK_INSERTSORT_TRUE@insertsort_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_INSERTSORT_TRUE@                           $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_INSERTSORT_TRUE@                           libinsertsort.la \
 @ENABLED_BENCHMARK_INSERTSORT_TRUE@                           $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_INSERTSORT_TRUE@                           libinsertsort.la \
 @ENABLED_BENCHMARK_INSERTSORT_TRUE@                           $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/janne_complex/Makefile.am
+++ b/src/janne_complex/Makefile.am
@@ -32,9 +32,8 @@ janne_complex_SOURCES       =
 libjanne_complex_la_SOURCES = libjanne_complex.c
 
 janne_complex_LDADD         = $(DUMMY_CRT0) \
-                              $(top_builddir)/support/libmain.la \
-                              libjanne_complex.la \
                               $(top_builddir)/support/libsupport.la \
+                              libjanne_complex.la \
                               $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/janne_complex/Makefile.in
+++ b/src/janne_complex/Makefile.in
@@ -171,9 +171,8 @@ janne_complex_OBJECTS = $(am_janne_complex_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_JANNE_COMPLEX_TRUE@janne_complex_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_JANNE_COMPLEX_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_JANNE_COMPLEX_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_JANNE_COMPLEX_TRUE@	libjanne_complex.la \
 @ENABLED_BENCHMARK_JANNE_COMPLEX_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_JANNE_COMPLEX_TRUE@	libjanne_complex.la \
 @ENABLED_BENCHMARK_JANNE_COMPLEX_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_JANNE_COMPLEX_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_JANNE_COMPLEX_TRUE@	$(am__DEPENDENCIES_1)
@@ -386,8 +385,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_JANNE_COMPLEX_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_JANNE_COMPLEX_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_JANNE_COMPLEX_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_JANNE_COMPLEX_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -397,9 +394,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_JANNE_COMPLEX_TRUE@janne_complex_SOURCES = 
 @ENABLED_BENCHMARK_JANNE_COMPLEX_TRUE@libjanne_complex_la_SOURCES = libjanne_complex.c
 @ENABLED_BENCHMARK_JANNE_COMPLEX_TRUE@janne_complex_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_JANNE_COMPLEX_TRUE@                              $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_JANNE_COMPLEX_TRUE@                              libjanne_complex.la \
 @ENABLED_BENCHMARK_JANNE_COMPLEX_TRUE@                              $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_JANNE_COMPLEX_TRUE@                              libjanne_complex.la \
 @ENABLED_BENCHMARK_JANNE_COMPLEX_TRUE@                              $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/jfdctint/Makefile.am
+++ b/src/jfdctint/Makefile.am
@@ -32,9 +32,8 @@ jfdctint_SOURCES       =
 libjfdctint_la_SOURCES = libjfdctint.c
 
 jfdctint_LDADD         = $(DUMMY_CRT0) \
-                         $(top_builddir)/support/libmain.la \
-                         libjfdctint.la \
                          $(top_builddir)/support/libsupport.la \
+                         libjfdctint.la \
                          $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/jfdctint/Makefile.in
+++ b/src/jfdctint/Makefile.in
@@ -170,9 +170,8 @@ jfdctint_OBJECTS = $(am_jfdctint_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_JFDCTINT_TRUE@jfdctint_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_JFDCTINT_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_JFDCTINT_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_JFDCTINT_TRUE@	libjfdctint.la \
 @ENABLED_BENCHMARK_JFDCTINT_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_JFDCTINT_TRUE@	libjfdctint.la \
 @ENABLED_BENCHMARK_JFDCTINT_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_JFDCTINT_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_JFDCTINT_TRUE@	$(am__DEPENDENCIES_1)
@@ -384,8 +383,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_JFDCTINT_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_JFDCTINT_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_JFDCTINT_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_JFDCTINT_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -395,9 +392,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_JFDCTINT_TRUE@jfdctint_SOURCES = 
 @ENABLED_BENCHMARK_JFDCTINT_TRUE@libjfdctint_la_SOURCES = libjfdctint.c
 @ENABLED_BENCHMARK_JFDCTINT_TRUE@jfdctint_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_JFDCTINT_TRUE@                         $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_JFDCTINT_TRUE@                         libjfdctint.la \
 @ENABLED_BENCHMARK_JFDCTINT_TRUE@                         $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_JFDCTINT_TRUE@                         libjfdctint.la \
 @ENABLED_BENCHMARK_JFDCTINT_TRUE@                         $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/lcdnum/Makefile.am
+++ b/src/lcdnum/Makefile.am
@@ -32,9 +32,8 @@ lcdnum_SOURCES       =
 liblcdnum_la_SOURCES = liblcdnum.c
 
 lcdnum_LDADD         = $(DUMMY_CRT0) \
-                       $(top_builddir)/support/libmain.la \
-                       liblcdnum.la \
                        $(top_builddir)/support/libsupport.la \
+                       liblcdnum.la \
                        $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/lcdnum/Makefile.in
+++ b/src/lcdnum/Makefile.in
@@ -169,9 +169,8 @@ lcdnum_OBJECTS = $(am_lcdnum_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_LCDNUM_TRUE@lcdnum_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_LCDNUM_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_LCDNUM_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_LCDNUM_TRUE@	liblcdnum.la \
 @ENABLED_BENCHMARK_LCDNUM_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_LCDNUM_TRUE@	liblcdnum.la \
 @ENABLED_BENCHMARK_LCDNUM_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_LCDNUM_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_LCDNUM_TRUE@	$(am__DEPENDENCIES_1)
@@ -383,8 +382,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_LCDNUM_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_LCDNUM_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_LCDNUM_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_LCDNUM_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -394,9 +391,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_LCDNUM_TRUE@lcdnum_SOURCES = 
 @ENABLED_BENCHMARK_LCDNUM_TRUE@liblcdnum_la_SOURCES = liblcdnum.c
 @ENABLED_BENCHMARK_LCDNUM_TRUE@lcdnum_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_LCDNUM_TRUE@                       $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_LCDNUM_TRUE@                       liblcdnum.la \
 @ENABLED_BENCHMARK_LCDNUM_TRUE@                       $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_LCDNUM_TRUE@                       liblcdnum.la \
 @ENABLED_BENCHMARK_LCDNUM_TRUE@                       $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/levenshtein/Makefile.am
+++ b/src/levenshtein/Makefile.am
@@ -32,9 +32,8 @@ levenshtein_SOURCES       =
 liblevenshtein_la_SOURCES = liblevenshtein.c
 
 levenshtein_LDADD         = $(DUMMY_CRT0) \
-                            $(top_builddir)/support/libmain.la \
-                            liblevenshtein.la \
                             $(top_builddir)/support/libsupport.la \
+                            liblevenshtein.la \
                             $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/levenshtein/Makefile.in
+++ b/src/levenshtein/Makefile.in
@@ -171,9 +171,8 @@ levenshtein_OBJECTS = $(am_levenshtein_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_LEVENSHTEIN_TRUE@levenshtein_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_LEVENSHTEIN_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_LEVENSHTEIN_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_LEVENSHTEIN_TRUE@	liblevenshtein.la \
 @ENABLED_BENCHMARK_LEVENSHTEIN_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_LEVENSHTEIN_TRUE@	liblevenshtein.la \
 @ENABLED_BENCHMARK_LEVENSHTEIN_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_LEVENSHTEIN_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_LEVENSHTEIN_TRUE@	$(am__DEPENDENCIES_1)
@@ -386,8 +385,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_LEVENSHTEIN_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_LEVENSHTEIN_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_LEVENSHTEIN_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_LEVENSHTEIN_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -397,9 +394,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_LEVENSHTEIN_TRUE@levenshtein_SOURCES = 
 @ENABLED_BENCHMARK_LEVENSHTEIN_TRUE@liblevenshtein_la_SOURCES = liblevenshtein.c
 @ENABLED_BENCHMARK_LEVENSHTEIN_TRUE@levenshtein_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_LEVENSHTEIN_TRUE@                            $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_LEVENSHTEIN_TRUE@                            liblevenshtein.la \
 @ENABLED_BENCHMARK_LEVENSHTEIN_TRUE@                            $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_LEVENSHTEIN_TRUE@                            liblevenshtein.la \
 @ENABLED_BENCHMARK_LEVENSHTEIN_TRUE@                            $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/ludcmp/Makefile.am
+++ b/src/ludcmp/Makefile.am
@@ -32,9 +32,8 @@ ludcmp_SOURCES       =
 libludcmp_la_SOURCES = libludcmp.c
 
 ludcmp_LDADD         = $(DUMMY_CRT0) \
-                       $(top_builddir)/support/libmain.la \
-                       libludcmp.la \
                        $(top_builddir)/support/libsupport.la \
+                       libludcmp.la \
                        $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/ludcmp/Makefile.in
+++ b/src/ludcmp/Makefile.in
@@ -169,9 +169,8 @@ ludcmp_OBJECTS = $(am_ludcmp_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_LUDCMP_TRUE@ludcmp_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_LUDCMP_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_LUDCMP_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_LUDCMP_TRUE@	libludcmp.la \
 @ENABLED_BENCHMARK_LUDCMP_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_LUDCMP_TRUE@	libludcmp.la \
 @ENABLED_BENCHMARK_LUDCMP_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_LUDCMP_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_LUDCMP_TRUE@	$(am__DEPENDENCIES_1)
@@ -383,8 +382,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_LUDCMP_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_LUDCMP_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_LUDCMP_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_LUDCMP_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -394,9 +391,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_LUDCMP_TRUE@ludcmp_SOURCES = 
 @ENABLED_BENCHMARK_LUDCMP_TRUE@libludcmp_la_SOURCES = libludcmp.c
 @ENABLED_BENCHMARK_LUDCMP_TRUE@ludcmp_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_LUDCMP_TRUE@                       $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_LUDCMP_TRUE@                       libludcmp.la \
 @ENABLED_BENCHMARK_LUDCMP_TRUE@                       $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_LUDCMP_TRUE@                       libludcmp.la \
 @ENABLED_BENCHMARK_LUDCMP_TRUE@                       $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/matmult-float/Makefile.am
+++ b/src/matmult-float/Makefile.am
@@ -33,9 +33,8 @@ matmult_float_SOURCES        =
 libmatmult_float_la_SOURCES  = matmult.c
 
 matmult_float_LDADD          = $(DUMMY_CRT0) \
-                               $(top_builddir)/support/libmain.la \
-                               libmatmult-float.la \
                                $(top_builddir)/support/libsupport.la \
+                               libmatmult-float.la \
                                $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 libmatmult_float_la_CPPFLAGS = -DMATMULT_FLOAT ${AM_CPPFLAGS}

--- a/src/matmult-float/Makefile.in
+++ b/src/matmult-float/Makefile.in
@@ -170,9 +170,8 @@ matmult_float_OBJECTS = $(am_matmult_float_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_MATMULT_FLOAT_TRUE@matmult_float_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_MATMULT_FLOAT_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_MATMULT_FLOAT_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_MATMULT_FLOAT_TRUE@	libmatmult-float.la \
 @ENABLED_BENCHMARK_MATMULT_FLOAT_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_MATMULT_FLOAT_TRUE@	libmatmult-float.la \
 @ENABLED_BENCHMARK_MATMULT_FLOAT_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_MATMULT_FLOAT_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_MATMULT_FLOAT_TRUE@	$(am__DEPENDENCIES_1)
@@ -385,8 +384,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_MATMULT_FLOAT_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_MATMULT_FLOAT_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_MATMULT_FLOAT_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_MATMULT_FLOAT_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -396,9 +393,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_MATMULT_FLOAT_TRUE@matmult_float_SOURCES = 
 @ENABLED_BENCHMARK_MATMULT_FLOAT_TRUE@libmatmult_float_la_SOURCES = matmult.c
 @ENABLED_BENCHMARK_MATMULT_FLOAT_TRUE@matmult_float_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_MATMULT_FLOAT_TRUE@                               $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_MATMULT_FLOAT_TRUE@                               libmatmult-float.la \
 @ENABLED_BENCHMARK_MATMULT_FLOAT_TRUE@                               $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_MATMULT_FLOAT_TRUE@                               libmatmult-float.la \
 @ENABLED_BENCHMARK_MATMULT_FLOAT_TRUE@                               $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 @ENABLED_BENCHMARK_MATMULT_FLOAT_TRUE@libmatmult_float_la_CPPFLAGS = -DMATMULT_FLOAT ${AM_CPPFLAGS}

--- a/src/matmult-int/Makefile.am
+++ b/src/matmult-int/Makefile.am
@@ -33,9 +33,8 @@ matmult_int_SOURCES        =
 libmatmult_int_la_SOURCES  = matmult.c
 
 matmult_int_LDADD          = $(DUMMY_CRT0) \
-                             $(top_builddir)/support/libmain.la \
-                             libmatmult-int.la \
                              $(top_builddir)/support/libsupport.la \
+                             libmatmult-int.la \
                              $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 libmatmult_int_la_CPPFLAGS = -DMATMULT_INT ${AM_CPPFLAGS}

--- a/src/matmult-int/Makefile.in
+++ b/src/matmult-int/Makefile.in
@@ -170,9 +170,8 @@ matmult_int_OBJECTS = $(am_matmult_int_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_MATMULT_INT_TRUE@matmult_int_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_MATMULT_INT_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_MATMULT_INT_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_MATMULT_INT_TRUE@	libmatmult-int.la \
 @ENABLED_BENCHMARK_MATMULT_INT_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_MATMULT_INT_TRUE@	libmatmult-int.la \
 @ENABLED_BENCHMARK_MATMULT_INT_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_MATMULT_INT_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_MATMULT_INT_TRUE@	$(am__DEPENDENCIES_1)
@@ -385,8 +384,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_MATMULT_INT_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_MATMULT_INT_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_MATMULT_INT_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_MATMULT_INT_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -396,9 +393,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_MATMULT_INT_TRUE@matmult_int_SOURCES = 
 @ENABLED_BENCHMARK_MATMULT_INT_TRUE@libmatmult_int_la_SOURCES = matmult.c
 @ENABLED_BENCHMARK_MATMULT_INT_TRUE@matmult_int_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_MATMULT_INT_TRUE@                             $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_MATMULT_INT_TRUE@                             libmatmult-int.la \
 @ENABLED_BENCHMARK_MATMULT_INT_TRUE@                             $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_MATMULT_INT_TRUE@                             libmatmult-int.la \
 @ENABLED_BENCHMARK_MATMULT_INT_TRUE@                             $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 @ENABLED_BENCHMARK_MATMULT_INT_TRUE@libmatmult_int_la_CPPFLAGS = -DMATMULT_INT ${AM_CPPFLAGS}

--- a/src/mergesort/Makefile.am
+++ b/src/mergesort/Makefile.am
@@ -32,9 +32,8 @@ mergesort_SOURCES       =
 libmergesort_la_SOURCES = libmergesort.c
 
 mergesort_LDADD         = $(DUMMY_CRT0) \
-                          $(top_builddir)/support/libmain.la \
-                          libmergesort.la \
                           $(top_builddir)/support/libsupport.la \
+                          libmergesort.la \
                           $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/mergesort/Makefile.in
+++ b/src/mergesort/Makefile.in
@@ -170,9 +170,8 @@ mergesort_OBJECTS = $(am_mergesort_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_MERGESORT_TRUE@mergesort_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_MERGESORT_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_MERGESORT_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_MERGESORT_TRUE@	libmergesort.la \
 @ENABLED_BENCHMARK_MERGESORT_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_MERGESORT_TRUE@	libmergesort.la \
 @ENABLED_BENCHMARK_MERGESORT_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_MERGESORT_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_MERGESORT_TRUE@	$(am__DEPENDENCIES_1)
@@ -385,8 +384,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_MERGESORT_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_MERGESORT_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_MERGESORT_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_MERGESORT_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -396,9 +393,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_MERGESORT_TRUE@mergesort_SOURCES = 
 @ENABLED_BENCHMARK_MERGESORT_TRUE@libmergesort_la_SOURCES = libmergesort.c
 @ENABLED_BENCHMARK_MERGESORT_TRUE@mergesort_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_MERGESORT_TRUE@                          $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_MERGESORT_TRUE@                          libmergesort.la \
 @ENABLED_BENCHMARK_MERGESORT_TRUE@                          $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_MERGESORT_TRUE@                          libmergesort.la \
 @ENABLED_BENCHMARK_MERGESORT_TRUE@                          $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/miniz/Makefile.am
+++ b/src/miniz/Makefile.am
@@ -33,9 +33,8 @@ libminiz_la_SOURCES = miniz.c miniz_b.c miniz.h
 libminiz_la_CFLAGS  = -fno-strict-aliasing ${AM_CFLAGS}
 
 miniz_LDADD         = $(DUMMY_CRT0) \
-                      $(top_builddir)/support/libmain.la \
-                      libminiz.la \
                       $(top_builddir)/support/libsupport.la \
+                      libminiz.la \
                       $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 endif

--- a/src/miniz/Makefile.in
+++ b/src/miniz/Makefile.in
@@ -174,9 +174,8 @@ miniz_OBJECTS = $(am_miniz_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_MINIZ_TRUE@miniz_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_MINIZ_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_MINIZ_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_MINIZ_TRUE@	libminiz.la \
 @ENABLED_BENCHMARK_MINIZ_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_MINIZ_TRUE@	libminiz.la \
 @ENABLED_BENCHMARK_MINIZ_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_MINIZ_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_MINIZ_TRUE@	$(am__DEPENDENCIES_1)
@@ -388,8 +387,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_MINIZ_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_MINIZ_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_MINIZ_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_MINIZ_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -400,9 +397,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_MINIZ_TRUE@libminiz_la_SOURCES = miniz.c miniz_b.c miniz.h
 @ENABLED_BENCHMARK_MINIZ_TRUE@libminiz_la_CFLAGS = -fno-strict-aliasing ${AM_CFLAGS}
 @ENABLED_BENCHMARK_MINIZ_TRUE@miniz_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_MINIZ_TRUE@                      $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_MINIZ_TRUE@                      libminiz.la \
 @ENABLED_BENCHMARK_MINIZ_TRUE@                      $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_MINIZ_TRUE@                      libminiz.la \
 @ENABLED_BENCHMARK_MINIZ_TRUE@                      $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/minver/Makefile.am
+++ b/src/minver/Makefile.am
@@ -32,9 +32,8 @@ minver_SOURCES       =
 libminver_la_SOURCES = libminver.c
 
 minver_LDADD         = $(DUMMY_CRT0) \
-                       $(top_builddir)/support/libmain.la \
-                       libminver.la \
                        $(top_builddir)/support/libsupport.la \
+                       libminver.la \
                        $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/minver/Makefile.in
+++ b/src/minver/Makefile.in
@@ -169,9 +169,8 @@ minver_OBJECTS = $(am_minver_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_MINVER_TRUE@minver_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_MINVER_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_MINVER_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_MINVER_TRUE@	libminver.la \
 @ENABLED_BENCHMARK_MINVER_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_MINVER_TRUE@	libminver.la \
 @ENABLED_BENCHMARK_MINVER_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_MINVER_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_MINVER_TRUE@	$(am__DEPENDENCIES_1)
@@ -383,8 +382,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_MINVER_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_MINVER_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_MINVER_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_MINVER_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -394,9 +391,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_MINVER_TRUE@minver_SOURCES = 
 @ENABLED_BENCHMARK_MINVER_TRUE@libminver_la_SOURCES = libminver.c
 @ENABLED_BENCHMARK_MINVER_TRUE@minver_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_MINVER_TRUE@                       $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_MINVER_TRUE@                       libminver.la \
 @ENABLED_BENCHMARK_MINVER_TRUE@                       $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_MINVER_TRUE@                       libminver.la \
 @ENABLED_BENCHMARK_MINVER_TRUE@                       $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/nbody/Makefile.am
+++ b/src/nbody/Makefile.am
@@ -32,9 +32,8 @@ nbody_SOURCES       =
 libnbody_la_SOURCES = nbody.c
 
 nbody_LDADD         = $(DUMMY_CRT0) \
-                      $(top_builddir)/support/libmain.la \
-                      libnbody.la \
                       $(top_builddir)/support/libsupport.la \
+                      libnbody.la \
                       $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT) \
                       $(LIBM)
 endif

--- a/src/nbody/Makefile.in
+++ b/src/nbody/Makefile.in
@@ -169,9 +169,8 @@ nbody_OBJECTS = $(am_nbody_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_NBODY_TRUE@nbody_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_NBODY_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_NBODY_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_NBODY_TRUE@	libnbody.la \
 @ENABLED_BENCHMARK_NBODY_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_NBODY_TRUE@	libnbody.la \
 @ENABLED_BENCHMARK_NBODY_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_NBODY_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_NBODY_TRUE@	$(am__DEPENDENCIES_1) $(LIBM)
@@ -383,8 +382,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_NBODY_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_NBODY_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_NBODY_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_NBODY_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -394,9 +391,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_NBODY_TRUE@nbody_SOURCES = 
 @ENABLED_BENCHMARK_NBODY_TRUE@libnbody_la_SOURCES = nbody.c
 @ENABLED_BENCHMARK_NBODY_TRUE@nbody_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_NBODY_TRUE@                      $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_NBODY_TRUE@                      libnbody.la \
 @ENABLED_BENCHMARK_NBODY_TRUE@                      $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_NBODY_TRUE@                      libnbody.la \
 @ENABLED_BENCHMARK_NBODY_TRUE@                      $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT) \
 @ENABLED_BENCHMARK_NBODY_TRUE@                      $(LIBM)
 

--- a/src/ndes/Makefile.am
+++ b/src/ndes/Makefile.am
@@ -32,9 +32,8 @@ ndes_SOURCES       =
 libndes_la_SOURCES = libndes.c
 
 ndes_LDADD         = $(DUMMY_CRT0) \
-                     $(top_builddir)/support/libmain.la \
-                     libndes.la \
                      $(top_builddir)/support/libsupport.la \
+                     libndes.la \
                      $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/ndes/Makefile.in
+++ b/src/ndes/Makefile.in
@@ -169,10 +169,8 @@ ndes_OBJECTS = $(am_ndes_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_NDES_TRUE@ndes_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_NDES_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_NDES_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_NDES_TRUE@	libndes.la \
 @ENABLED_BENCHMARK_NDES_TRUE@	$(top_builddir)/support/libsupport.la \
-@ENABLED_BENCHMARK_NDES_TRUE@	$(am__DEPENDENCIES_1) \
+@ENABLED_BENCHMARK_NDES_TRUE@	libndes.la $(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_NDES_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_NDES_TRUE@	$(am__DEPENDENCIES_1)
 AM_V_P = $(am__v_P_@AM_V@)
@@ -383,8 +381,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_NDES_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_NDES_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_NDES_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_NDES_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -394,9 +390,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_NDES_TRUE@ndes_SOURCES = 
 @ENABLED_BENCHMARK_NDES_TRUE@libndes_la_SOURCES = libndes.c
 @ENABLED_BENCHMARK_NDES_TRUE@ndes_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_NDES_TRUE@                     $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_NDES_TRUE@                     libndes.la \
 @ENABLED_BENCHMARK_NDES_TRUE@                     $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_NDES_TRUE@                     libndes.la \
 @ENABLED_BENCHMARK_NDES_TRUE@                     $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/nettle-arcfour/Makefile.am
+++ b/src/nettle-arcfour/Makefile.am
@@ -32,9 +32,8 @@ nettle_arcfour_SOURCES       =
 libnettle_arcfour_la_SOURCES = arcfour.c
 
 nettle_arcfour_LDADD         = $(DUMMY_CRT0) \
-                               $(top_builddir)/support/libmain.la \
-                               libnettle-arcfour.la \
                                $(top_builddir)/support/libsupport.la \
+                               libnettle-arcfour.la \
                                $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/nettle-arcfour/Makefile.in
+++ b/src/nettle-arcfour/Makefile.in
@@ -170,9 +170,8 @@ nettle_arcfour_OBJECTS = $(am_nettle_arcfour_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_NETTLE_ARCFOUR_TRUE@nettle_arcfour_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_NETTLE_ARCFOUR_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_NETTLE_ARCFOUR_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_NETTLE_ARCFOUR_TRUE@	libnettle-arcfour.la \
 @ENABLED_BENCHMARK_NETTLE_ARCFOUR_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_NETTLE_ARCFOUR_TRUE@	libnettle-arcfour.la \
 @ENABLED_BENCHMARK_NETTLE_ARCFOUR_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_NETTLE_ARCFOUR_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_NETTLE_ARCFOUR_TRUE@	$(am__DEPENDENCIES_1)
@@ -385,8 +384,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_NETTLE_ARCFOUR_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_NETTLE_ARCFOUR_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_NETTLE_ARCFOUR_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_NETTLE_ARCFOUR_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -396,9 +393,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_NETTLE_ARCFOUR_TRUE@nettle_arcfour_SOURCES = 
 @ENABLED_BENCHMARK_NETTLE_ARCFOUR_TRUE@libnettle_arcfour_la_SOURCES = arcfour.c
 @ENABLED_BENCHMARK_NETTLE_ARCFOUR_TRUE@nettle_arcfour_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_NETTLE_ARCFOUR_TRUE@                               $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_NETTLE_ARCFOUR_TRUE@                               libnettle-arcfour.la \
 @ENABLED_BENCHMARK_NETTLE_ARCFOUR_TRUE@                               $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_NETTLE_ARCFOUR_TRUE@                               libnettle-arcfour.la \
 @ENABLED_BENCHMARK_NETTLE_ARCFOUR_TRUE@                               $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/nettle-cast128/Makefile.am
+++ b/src/nettle-cast128/Makefile.am
@@ -32,9 +32,8 @@ nettle_cast128_SOURCES       =
 libnettle_cast128_la_SOURCES = cast128.c
 
 nettle_cast128_LDADD         = $(DUMMY_CRT0) \
-                               $(top_builddir)/support/libmain.la \
-                               libnettle-cast128.la \
                                $(top_builddir)/support/libsupport.la \
+                               libnettle-cast128.la \
                                $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/nettle-cast128/Makefile.in
+++ b/src/nettle-cast128/Makefile.in
@@ -170,9 +170,8 @@ nettle_cast128_OBJECTS = $(am_nettle_cast128_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_NETTLE_CAST128_TRUE@nettle_cast128_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_NETTLE_CAST128_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_NETTLE_CAST128_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_NETTLE_CAST128_TRUE@	libnettle-cast128.la \
 @ENABLED_BENCHMARK_NETTLE_CAST128_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_NETTLE_CAST128_TRUE@	libnettle-cast128.la \
 @ENABLED_BENCHMARK_NETTLE_CAST128_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_NETTLE_CAST128_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_NETTLE_CAST128_TRUE@	$(am__DEPENDENCIES_1)
@@ -385,8 +384,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_NETTLE_CAST128_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_NETTLE_CAST128_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_NETTLE_CAST128_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_NETTLE_CAST128_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -396,9 +393,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_NETTLE_CAST128_TRUE@nettle_cast128_SOURCES = 
 @ENABLED_BENCHMARK_NETTLE_CAST128_TRUE@libnettle_cast128_la_SOURCES = cast128.c
 @ENABLED_BENCHMARK_NETTLE_CAST128_TRUE@nettle_cast128_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_NETTLE_CAST128_TRUE@                               $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_NETTLE_CAST128_TRUE@                               libnettle-cast128.la \
 @ENABLED_BENCHMARK_NETTLE_CAST128_TRUE@                               $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_NETTLE_CAST128_TRUE@                               libnettle-cast128.la \
 @ENABLED_BENCHMARK_NETTLE_CAST128_TRUE@                               $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/nettle-des/Makefile.am
+++ b/src/nettle-des/Makefile.am
@@ -35,9 +35,8 @@ libnettle_des_la_SOURCES = des.c \
 	                   desCode.h
 
 nettle_des_LDADD         = $(DUMMY_CRT0) \
-                           $(top_builddir)/support/libmain.la \
-                           libnettle-des.la \
                            $(top_builddir)/support/libsupport.la \
+                           libnettle-des.la \
                            $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 EXTRA_DIST = descore.README

--- a/src/nettle-des/Makefile.in
+++ b/src/nettle-des/Makefile.in
@@ -170,9 +170,8 @@ nettle_des_OBJECTS = $(am_nettle_des_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_NETTLE_DES_TRUE@nettle_des_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_NETTLE_DES_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_NETTLE_DES_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_NETTLE_DES_TRUE@	libnettle-des.la \
 @ENABLED_BENCHMARK_NETTLE_DES_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_NETTLE_DES_TRUE@	libnettle-des.la \
 @ENABLED_BENCHMARK_NETTLE_DES_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_NETTLE_DES_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_NETTLE_DES_TRUE@	$(am__DEPENDENCIES_1)
@@ -385,8 +384,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_NETTLE_DES_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_NETTLE_DES_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_NETTLE_DES_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_NETTLE_DES_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -400,9 +397,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_NETTLE_DES_TRUE@	                   desCode.h
 
 @ENABLED_BENCHMARK_NETTLE_DES_TRUE@nettle_des_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_NETTLE_DES_TRUE@                           $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_NETTLE_DES_TRUE@                           libnettle-des.la \
 @ENABLED_BENCHMARK_NETTLE_DES_TRUE@                           $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_NETTLE_DES_TRUE@                           libnettle-des.la \
 @ENABLED_BENCHMARK_NETTLE_DES_TRUE@                           $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 @ENABLED_BENCHMARK_NETTLE_DES_TRUE@EXTRA_DIST = descore.README

--- a/src/nettle-md5/Makefile.am
+++ b/src/nettle-md5/Makefile.am
@@ -32,9 +32,8 @@ nettle_md5_SOURCES       =
 libnettle_md5_la_SOURCES = md5.c
 
 nettle_md5_LDADD         = $(DUMMY_CRT0) \
-                           $(top_builddir)/support/libmain.la \
-                           libnettle-md5.la \
                            $(top_builddir)/support/libsupport.la \
+                           libnettle-md5.la \
                            $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 endif

--- a/src/nettle-md5/Makefile.in
+++ b/src/nettle-md5/Makefile.in
@@ -170,9 +170,8 @@ nettle_md5_OBJECTS = $(am_nettle_md5_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_NETTLE_MD5_TRUE@nettle_md5_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_NETTLE_MD5_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_NETTLE_MD5_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_NETTLE_MD5_TRUE@	libnettle-md5.la \
 @ENABLED_BENCHMARK_NETTLE_MD5_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_NETTLE_MD5_TRUE@	libnettle-md5.la \
 @ENABLED_BENCHMARK_NETTLE_MD5_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_NETTLE_MD5_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_NETTLE_MD5_TRUE@	$(am__DEPENDENCIES_1)
@@ -385,8 +384,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_NETTLE_MD5_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_NETTLE_MD5_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_NETTLE_MD5_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_NETTLE_MD5_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -396,9 +393,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_NETTLE_MD5_TRUE@nettle_md5_SOURCES = 
 @ENABLED_BENCHMARK_NETTLE_MD5_TRUE@libnettle_md5_la_SOURCES = md5.c
 @ENABLED_BENCHMARK_NETTLE_MD5_TRUE@nettle_md5_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_NETTLE_MD5_TRUE@                           $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_NETTLE_MD5_TRUE@                           libnettle-md5.la \
 @ENABLED_BENCHMARK_NETTLE_MD5_TRUE@                           $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_NETTLE_MD5_TRUE@                           libnettle-md5.la \
 @ENABLED_BENCHMARK_NETTLE_MD5_TRUE@                           $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/nettle-sha256/Makefile.am
+++ b/src/nettle-sha256/Makefile.am
@@ -32,9 +32,8 @@ nettle_sha256_SOURCES       =
 libnettle_sha256_la_SOURCES = nettle-sha256.c
 
 nettle_sha256_LDADD         = $(DUMMY_CRT0) \
-                              $(top_builddir)/support/libmain.la \
-                              libnettle-sha256.la \
                               $(top_builddir)/support/libsupport.la \
+                              libnettle-sha256.la \
                               $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 endif

--- a/src/nettle-sha256/Makefile.in
+++ b/src/nettle-sha256/Makefile.in
@@ -171,9 +171,8 @@ nettle_sha256_OBJECTS = $(am_nettle_sha256_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_NETTLE_SHA256_TRUE@nettle_sha256_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_NETTLE_SHA256_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_NETTLE_SHA256_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_NETTLE_SHA256_TRUE@	libnettle-sha256.la \
 @ENABLED_BENCHMARK_NETTLE_SHA256_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_NETTLE_SHA256_TRUE@	libnettle-sha256.la \
 @ENABLED_BENCHMARK_NETTLE_SHA256_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_NETTLE_SHA256_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_NETTLE_SHA256_TRUE@	$(am__DEPENDENCIES_1)
@@ -386,8 +385,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_NETTLE_SHA256_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_NETTLE_SHA256_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_NETTLE_SHA256_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_NETTLE_SHA256_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -397,9 +394,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_NETTLE_SHA256_TRUE@nettle_sha256_SOURCES = 
 @ENABLED_BENCHMARK_NETTLE_SHA256_TRUE@libnettle_sha256_la_SOURCES = nettle-sha256.c
 @ENABLED_BENCHMARK_NETTLE_SHA256_TRUE@nettle_sha256_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_NETTLE_SHA256_TRUE@                              $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_NETTLE_SHA256_TRUE@                              libnettle-sha256.la \
 @ENABLED_BENCHMARK_NETTLE_SHA256_TRUE@                              $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_NETTLE_SHA256_TRUE@                              libnettle-sha256.la \
 @ENABLED_BENCHMARK_NETTLE_SHA256_TRUE@                              $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/newlib-exp/Makefile.am
+++ b/src/newlib-exp/Makefile.am
@@ -32,9 +32,8 @@ newlib_exp_SOURCES       =
 libnewlib_exp_la_SOURCES = ef_exp.c
 
 newlib_exp_LDADD         = $(DUMMY_CRT0) \
-                           $(top_builddir)/support/libmain.la \
-                           libnewlib-exp.la \
                            $(top_builddir)/support/libsupport.la \
+                           libnewlib-exp.la \
                            $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/newlib-exp/Makefile.in
+++ b/src/newlib-exp/Makefile.in
@@ -170,9 +170,8 @@ newlib_exp_OBJECTS = $(am_newlib_exp_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_NEWLIB_EXP_TRUE@newlib_exp_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_NEWLIB_EXP_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_NEWLIB_EXP_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_NEWLIB_EXP_TRUE@	libnewlib-exp.la \
 @ENABLED_BENCHMARK_NEWLIB_EXP_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_NEWLIB_EXP_TRUE@	libnewlib-exp.la \
 @ENABLED_BENCHMARK_NEWLIB_EXP_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_NEWLIB_EXP_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_NEWLIB_EXP_TRUE@	$(am__DEPENDENCIES_1)
@@ -385,8 +384,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_NEWLIB_EXP_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_NEWLIB_EXP_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_NEWLIB_EXP_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_NEWLIB_EXP_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -396,9 +393,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_NEWLIB_EXP_TRUE@newlib_exp_SOURCES = 
 @ENABLED_BENCHMARK_NEWLIB_EXP_TRUE@libnewlib_exp_la_SOURCES = ef_exp.c
 @ENABLED_BENCHMARK_NEWLIB_EXP_TRUE@newlib_exp_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_NEWLIB_EXP_TRUE@                           $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_NEWLIB_EXP_TRUE@                           libnewlib-exp.la \
 @ENABLED_BENCHMARK_NEWLIB_EXP_TRUE@                           $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_NEWLIB_EXP_TRUE@                           libnewlib-exp.la \
 @ENABLED_BENCHMARK_NEWLIB_EXP_TRUE@                           $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/newlib-log/Makefile.am
+++ b/src/newlib-log/Makefile.am
@@ -32,9 +32,8 @@ newlib_log_SOURCES       =
 libnewlib_log_la_SOURCES = ef_log.c
 
 newlib_log_LDADD         = $(DUMMY_CRT0) \
-                           $(top_builddir)/support/libmain.la \
-                           libnewlib-log.la \
                            $(top_builddir)/support/libsupport.la \
+                           libnewlib-log.la \
                            $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/newlib-log/Makefile.in
+++ b/src/newlib-log/Makefile.in
@@ -170,9 +170,8 @@ newlib_log_OBJECTS = $(am_newlib_log_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_NEWLIB_LOG_TRUE@newlib_log_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_NEWLIB_LOG_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_NEWLIB_LOG_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_NEWLIB_LOG_TRUE@	libnewlib-log.la \
 @ENABLED_BENCHMARK_NEWLIB_LOG_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_NEWLIB_LOG_TRUE@	libnewlib-log.la \
 @ENABLED_BENCHMARK_NEWLIB_LOG_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_NEWLIB_LOG_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_NEWLIB_LOG_TRUE@	$(am__DEPENDENCIES_1)
@@ -385,8 +384,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_NEWLIB_LOG_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_NEWLIB_LOG_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_NEWLIB_LOG_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_NEWLIB_LOG_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -396,9 +393,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_NEWLIB_LOG_TRUE@newlib_log_SOURCES = 
 @ENABLED_BENCHMARK_NEWLIB_LOG_TRUE@libnewlib_log_la_SOURCES = ef_log.c
 @ENABLED_BENCHMARK_NEWLIB_LOG_TRUE@newlib_log_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_NEWLIB_LOG_TRUE@                           $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_NEWLIB_LOG_TRUE@                           libnewlib-log.la \
 @ENABLED_BENCHMARK_NEWLIB_LOG_TRUE@                           $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_NEWLIB_LOG_TRUE@                           libnewlib-log.la \
 @ENABLED_BENCHMARK_NEWLIB_LOG_TRUE@                           $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/newlib-mod/Makefile.am
+++ b/src/newlib-mod/Makefile.am
@@ -32,9 +32,8 @@ newlib_mod_SOURCES       =
 libnewlib_mod_la_SOURCES = ef_mod.c
 
 newlib_mod_LDADD         = $(DUMMY_CRT0) \
-                           $(top_builddir)/support/libmain.la \
-                           libnewlib-mod.la \
                            $(top_builddir)/support/libsupport.la \
+                           libnewlib-mod.la \
                            $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/newlib-mod/Makefile.in
+++ b/src/newlib-mod/Makefile.in
@@ -170,9 +170,8 @@ newlib_mod_OBJECTS = $(am_newlib_mod_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_NEWLIB_MOD_TRUE@newlib_mod_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_NEWLIB_MOD_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_NEWLIB_MOD_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_NEWLIB_MOD_TRUE@	libnewlib-mod.la \
 @ENABLED_BENCHMARK_NEWLIB_MOD_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_NEWLIB_MOD_TRUE@	libnewlib-mod.la \
 @ENABLED_BENCHMARK_NEWLIB_MOD_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_NEWLIB_MOD_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_NEWLIB_MOD_TRUE@	$(am__DEPENDENCIES_1)
@@ -385,8 +384,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_NEWLIB_MOD_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_NEWLIB_MOD_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_NEWLIB_MOD_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_NEWLIB_MOD_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -396,9 +393,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_NEWLIB_MOD_TRUE@newlib_mod_SOURCES = 
 @ENABLED_BENCHMARK_NEWLIB_MOD_TRUE@libnewlib_mod_la_SOURCES = ef_mod.c
 @ENABLED_BENCHMARK_NEWLIB_MOD_TRUE@newlib_mod_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_NEWLIB_MOD_TRUE@                           $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_NEWLIB_MOD_TRUE@                           libnewlib-mod.la \
 @ENABLED_BENCHMARK_NEWLIB_MOD_TRUE@                           $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_NEWLIB_MOD_TRUE@                           libnewlib-mod.la \
 @ENABLED_BENCHMARK_NEWLIB_MOD_TRUE@                           $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/newlib-sqrt/Makefile.am
+++ b/src/newlib-sqrt/Makefile.am
@@ -32,9 +32,8 @@ newlib_sqrt_SOURCES       =
 libnewlib_sqrt_la_SOURCES = ef_sqrt.c
 
 newlib_sqrt_LDADD         = $(DUMMY_CRT0) \
-                            $(top_builddir)/support/libmain.la \
-                            libnewlib-sqrt.la \
                             $(top_builddir)/support/libsupport.la \
+                            libnewlib-sqrt.la \
                             $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/newlib-sqrt/Makefile.in
+++ b/src/newlib-sqrt/Makefile.in
@@ -171,9 +171,8 @@ newlib_sqrt_OBJECTS = $(am_newlib_sqrt_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_NEWLIB_SQRT_TRUE@newlib_sqrt_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_NEWLIB_SQRT_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_NEWLIB_SQRT_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_NEWLIB_SQRT_TRUE@	libnewlib-sqrt.la \
 @ENABLED_BENCHMARK_NEWLIB_SQRT_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_NEWLIB_SQRT_TRUE@	libnewlib-sqrt.la \
 @ENABLED_BENCHMARK_NEWLIB_SQRT_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_NEWLIB_SQRT_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_NEWLIB_SQRT_TRUE@	$(am__DEPENDENCIES_1)
@@ -386,8 +385,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_NEWLIB_SQRT_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_NEWLIB_SQRT_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_NEWLIB_SQRT_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_NEWLIB_SQRT_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -397,9 +394,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_NEWLIB_SQRT_TRUE@newlib_sqrt_SOURCES = 
 @ENABLED_BENCHMARK_NEWLIB_SQRT_TRUE@libnewlib_sqrt_la_SOURCES = ef_sqrt.c
 @ENABLED_BENCHMARK_NEWLIB_SQRT_TRUE@newlib_sqrt_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_NEWLIB_SQRT_TRUE@                            $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_NEWLIB_SQRT_TRUE@                            libnewlib-sqrt.la \
 @ENABLED_BENCHMARK_NEWLIB_SQRT_TRUE@                            $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_NEWLIB_SQRT_TRUE@                            libnewlib-sqrt.la \
 @ENABLED_BENCHMARK_NEWLIB_SQRT_TRUE@                            $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/ns/Makefile.am
+++ b/src/ns/Makefile.am
@@ -32,9 +32,8 @@ ns_SOURCES         =
 libns_la_SOURCES = libns.c
 
 ns_LDADD           = $(DUMMY_CRT0) \
-                     $(top_builddir)/support/libmain.la \
-                     libns.la \
                      $(top_builddir)/support/libsupport.la \
+                     libns.la \
                      $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/ns/Makefile.in
+++ b/src/ns/Makefile.in
@@ -168,10 +168,8 @@ am_ns_OBJECTS =
 ns_OBJECTS = $(am_ns_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_NS_TRUE@ns_DEPENDENCIES = $(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_NS_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_NS_TRUE@	libns.la \
 @ENABLED_BENCHMARK_NS_TRUE@	$(top_builddir)/support/libsupport.la \
-@ENABLED_BENCHMARK_NS_TRUE@	$(am__DEPENDENCIES_1) \
+@ENABLED_BENCHMARK_NS_TRUE@	libns.la $(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_NS_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_NS_TRUE@	$(am__DEPENDENCIES_1)
 AM_V_P = $(am__v_P_@AM_V@)
@@ -382,8 +380,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_NS_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_NS_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_NS_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_NS_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -393,9 +389,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_NS_TRUE@ns_SOURCES = 
 @ENABLED_BENCHMARK_NS_TRUE@libns_la_SOURCES = libns.c
 @ENABLED_BENCHMARK_NS_TRUE@ns_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_NS_TRUE@                     $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_NS_TRUE@                     libns.la \
 @ENABLED_BENCHMARK_NS_TRUE@                     $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_NS_TRUE@                     libns.la \
 @ENABLED_BENCHMARK_NS_TRUE@                     $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/nsichneu/Makefile.am
+++ b/src/nsichneu/Makefile.am
@@ -32,9 +32,8 @@ nsichneu_SOURCES       =
 libnsichneu_la_SOURCES = libnsichneu.c
 
 nsichneu_LDADD         = $(DUMMY_CRT0) \
-                         $(top_builddir)/support/libmain.la \
-                         libnsichneu.la \
                          $(top_builddir)/support/libsupport.la \
+                         libnsichneu.la \
                          $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/nsichneu/Makefile.in
+++ b/src/nsichneu/Makefile.in
@@ -170,9 +170,8 @@ nsichneu_OBJECTS = $(am_nsichneu_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_NSICHNEU_TRUE@nsichneu_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_NSICHNEU_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_NSICHNEU_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_NSICHNEU_TRUE@	libnsichneu.la \
 @ENABLED_BENCHMARK_NSICHNEU_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_NSICHNEU_TRUE@	libnsichneu.la \
 @ENABLED_BENCHMARK_NSICHNEU_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_NSICHNEU_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_NSICHNEU_TRUE@	$(am__DEPENDENCIES_1)
@@ -384,8 +383,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_NSICHNEU_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_NSICHNEU_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_NSICHNEU_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_NSICHNEU_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -395,9 +392,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_NSICHNEU_TRUE@nsichneu_SOURCES = 
 @ENABLED_BENCHMARK_NSICHNEU_TRUE@libnsichneu_la_SOURCES = libnsichneu.c
 @ENABLED_BENCHMARK_NSICHNEU_TRUE@nsichneu_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_NSICHNEU_TRUE@                         $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_NSICHNEU_TRUE@                         libnsichneu.la \
 @ENABLED_BENCHMARK_NSICHNEU_TRUE@                         $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_NSICHNEU_TRUE@                         libnsichneu.la \
 @ENABLED_BENCHMARK_NSICHNEU_TRUE@                         $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/picojpeg/Makefile.am
+++ b/src/picojpeg/Makefile.am
@@ -32,9 +32,8 @@ picojpeg_SOURCES       =
 libpicojpeg_la_SOURCES = libpicojpeg.c picojpeg_test.c picojpeg.h
 
 picojpeg_LDADD         = $(DUMMY_CRT0) \
-                         $(top_builddir)/support/libmain.la \
-                         libpicojpeg.la \
                          $(top_builddir)/support/libsupport.la \
+                         libpicojpeg.la \
                          $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/picojpeg/Makefile.in
+++ b/src/picojpeg/Makefile.in
@@ -172,9 +172,8 @@ picojpeg_OBJECTS = $(am_picojpeg_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_PICOJPEG_TRUE@picojpeg_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_PICOJPEG_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_PICOJPEG_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_PICOJPEG_TRUE@	libpicojpeg.la \
 @ENABLED_BENCHMARK_PICOJPEG_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_PICOJPEG_TRUE@	libpicojpeg.la \
 @ENABLED_BENCHMARK_PICOJPEG_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_PICOJPEG_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_PICOJPEG_TRUE@	$(am__DEPENDENCIES_1)
@@ -386,8 +385,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_PICOJPEG_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_PICOJPEG_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_PICOJPEG_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_PICOJPEG_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -397,9 +394,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_PICOJPEG_TRUE@picojpeg_SOURCES = 
 @ENABLED_BENCHMARK_PICOJPEG_TRUE@libpicojpeg_la_SOURCES = libpicojpeg.c picojpeg_test.c picojpeg.h
 @ENABLED_BENCHMARK_PICOJPEG_TRUE@picojpeg_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_PICOJPEG_TRUE@                         $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_PICOJPEG_TRUE@                         libpicojpeg.la \
 @ENABLED_BENCHMARK_PICOJPEG_TRUE@                         $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_PICOJPEG_TRUE@                         libpicojpeg.la \
 @ENABLED_BENCHMARK_PICOJPEG_TRUE@                         $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/prime/Makefile.am
+++ b/src/prime/Makefile.am
@@ -32,9 +32,8 @@ prime_SOURCES       =
 libprime_la_SOURCES = libprime.c
 
 prime_LDADD         = $(DUMMY_CRT0) \
-                      $(top_builddir)/support/libmain.la \
-                      libprime.la \
                       $(top_builddir)/support/libsupport.la \
+                      libprime.la \
                       $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/prime/Makefile.in
+++ b/src/prime/Makefile.in
@@ -169,9 +169,8 @@ prime_OBJECTS = $(am_prime_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_PRIME_TRUE@prime_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_PRIME_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_PRIME_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_PRIME_TRUE@	libprime.la \
 @ENABLED_BENCHMARK_PRIME_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_PRIME_TRUE@	libprime.la \
 @ENABLED_BENCHMARK_PRIME_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_PRIME_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_PRIME_TRUE@	$(am__DEPENDENCIES_1)
@@ -383,8 +382,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_PRIME_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_PRIME_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_PRIME_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_PRIME_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -394,9 +391,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_PRIME_TRUE@prime_SOURCES = 
 @ENABLED_BENCHMARK_PRIME_TRUE@libprime_la_SOURCES = libprime.c
 @ENABLED_BENCHMARK_PRIME_TRUE@prime_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_PRIME_TRUE@                      $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_PRIME_TRUE@                      libprime.la \
 @ENABLED_BENCHMARK_PRIME_TRUE@                      $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_PRIME_TRUE@                      libprime.la \
 @ENABLED_BENCHMARK_PRIME_TRUE@                      $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/qrduino/Makefile.am
+++ b/src/qrduino/Makefile.am
@@ -32,9 +32,8 @@ qrduino_SOURCES       =
 libqrduino_la_SOURCES = qrtest.c qrencode.c qrencode.h qrframe.c ecctable.h qrbits.h
 
 qrduino_LDADD         = $(DUMMY_CRT0) \
-                        $(top_builddir)/support/libmain.la \
-                        libqrduino.la \
                         $(top_builddir)/support/libsupport.la \
+                        libqrduino.la \
                         $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/qrduino/Makefile.in
+++ b/src/qrduino/Makefile.in
@@ -171,9 +171,8 @@ qrduino_OBJECTS = $(am_qrduino_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_QRDUINO_TRUE@qrduino_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_QRDUINO_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_QRDUINO_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_QRDUINO_TRUE@	libqrduino.la \
 @ENABLED_BENCHMARK_QRDUINO_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_QRDUINO_TRUE@	libqrduino.la \
 @ENABLED_BENCHMARK_QRDUINO_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_QRDUINO_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_QRDUINO_TRUE@	$(am__DEPENDENCIES_1)
@@ -385,8 +384,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_QRDUINO_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_QRDUINO_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_QRDUINO_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_QRDUINO_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -396,9 +393,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_QRDUINO_TRUE@qrduino_SOURCES = 
 @ENABLED_BENCHMARK_QRDUINO_TRUE@libqrduino_la_SOURCES = qrtest.c qrencode.c qrencode.h qrframe.c ecctable.h qrbits.h
 @ENABLED_BENCHMARK_QRDUINO_TRUE@qrduino_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_QRDUINO_TRUE@                        $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_QRDUINO_TRUE@                        libqrduino.la \
 @ENABLED_BENCHMARK_QRDUINO_TRUE@                        $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_QRDUINO_TRUE@                        libqrduino.la \
 @ENABLED_BENCHMARK_QRDUINO_TRUE@                        $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/qsort/Makefile.am
+++ b/src/qsort/Makefile.am
@@ -32,9 +32,8 @@ qsort_SOURCES       =
 libqsort_la_SOURCES = libqsort.c
 
 qsort_LDADD         = $(DUMMY_CRT0) \
-                      $(top_builddir)/support/libmain.la \
-                      libqsort.la \
                       $(top_builddir)/support/libsupport.la \
+                      libqsort.la \
                       $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/qsort/Makefile.in
+++ b/src/qsort/Makefile.in
@@ -169,9 +169,8 @@ qsort_OBJECTS = $(am_qsort_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_QSORT_TRUE@qsort_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_QSORT_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_QSORT_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_QSORT_TRUE@	libqsort.la \
 @ENABLED_BENCHMARK_QSORT_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_QSORT_TRUE@	libqsort.la \
 @ENABLED_BENCHMARK_QSORT_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_QSORT_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_QSORT_TRUE@	$(am__DEPENDENCIES_1)
@@ -383,8 +382,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_QSORT_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_QSORT_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_QSORT_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_QSORT_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -394,9 +391,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_QSORT_TRUE@qsort_SOURCES = 
 @ENABLED_BENCHMARK_QSORT_TRUE@libqsort_la_SOURCES = libqsort.c
 @ENABLED_BENCHMARK_QSORT_TRUE@qsort_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_QSORT_TRUE@                      $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_QSORT_TRUE@                      libqsort.la \
 @ENABLED_BENCHMARK_QSORT_TRUE@                      $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_QSORT_TRUE@                      libqsort.la \
 @ENABLED_BENCHMARK_QSORT_TRUE@                      $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/qurt/Makefile.am
+++ b/src/qurt/Makefile.am
@@ -32,9 +32,8 @@ qurt_SOURCES       =
 libqurt_la_SOURCES = libqurt.c
 
 qurt_LDADD         = $(DUMMY_CRT0) \
-                     $(top_builddir)/support/libmain.la \
-                     libqurt.la \
                      $(top_builddir)/support/libsupport.la \
+                     libqurt.la \
                      $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/qurt/Makefile.in
+++ b/src/qurt/Makefile.in
@@ -169,10 +169,8 @@ qurt_OBJECTS = $(am_qurt_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_QURT_TRUE@qurt_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_QURT_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_QURT_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_QURT_TRUE@	libqurt.la \
 @ENABLED_BENCHMARK_QURT_TRUE@	$(top_builddir)/support/libsupport.la \
-@ENABLED_BENCHMARK_QURT_TRUE@	$(am__DEPENDENCIES_1) \
+@ENABLED_BENCHMARK_QURT_TRUE@	libqurt.la $(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_QURT_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_QURT_TRUE@	$(am__DEPENDENCIES_1)
 AM_V_P = $(am__v_P_@AM_V@)
@@ -383,8 +381,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_QURT_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_QURT_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_QURT_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_QURT_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -394,9 +390,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_QURT_TRUE@qurt_SOURCES = 
 @ENABLED_BENCHMARK_QURT_TRUE@libqurt_la_SOURCES = libqurt.c
 @ENABLED_BENCHMARK_QURT_TRUE@qurt_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_QURT_TRUE@                     $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_QURT_TRUE@                     libqurt.la \
 @ENABLED_BENCHMARK_QURT_TRUE@                     $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_QURT_TRUE@                     libqurt.la \
 @ENABLED_BENCHMARK_QURT_TRUE@                     $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/recursion/Makefile.am
+++ b/src/recursion/Makefile.am
@@ -32,9 +32,8 @@ recursion_SOURCES       =
 librecursion_la_SOURCES = librecursion.c
 
 recursion_LDADD         = $(DUMMY_CRT0) \
-                          $(top_builddir)/support/libmain.la \
-                          librecursion.la \
                           $(top_builddir)/support/libsupport.la \
+                          librecursion.la \
                           $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/recursion/Makefile.in
+++ b/src/recursion/Makefile.in
@@ -170,9 +170,8 @@ recursion_OBJECTS = $(am_recursion_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_RECURSION_TRUE@recursion_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_RECURSION_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_RECURSION_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_RECURSION_TRUE@	librecursion.la \
 @ENABLED_BENCHMARK_RECURSION_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_RECURSION_TRUE@	librecursion.la \
 @ENABLED_BENCHMARK_RECURSION_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_RECURSION_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_RECURSION_TRUE@	$(am__DEPENDENCIES_1)
@@ -385,8 +384,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_RECURSION_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_RECURSION_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_RECURSION_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_RECURSION_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -396,9 +393,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_RECURSION_TRUE@recursion_SOURCES = 
 @ENABLED_BENCHMARK_RECURSION_TRUE@librecursion_la_SOURCES = librecursion.c
 @ENABLED_BENCHMARK_RECURSION_TRUE@recursion_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_RECURSION_TRUE@                          $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_RECURSION_TRUE@                          librecursion.la \
 @ENABLED_BENCHMARK_RECURSION_TRUE@                          $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_RECURSION_TRUE@                          librecursion.la \
 @ENABLED_BENCHMARK_RECURSION_TRUE@                          $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/rijndael/Makefile.am
+++ b/src/rijndael/Makefile.am
@@ -33,9 +33,8 @@ rijndael_SOURCES       =
 librijndael_la_SOURCES = aes.c aes.h aestab.h aesxam.c
 
 rijndael_LDADD         = $(DUMMY_CRT0) \
-                         $(top_builddir)/support/libmain.la \
-                         librijndael.la \
                          $(top_builddir)/support/libsupport.la \
+                         librijndael.la \
                          $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 rijndael_CFLAGS  = -fno-strict-aliasing ${AM_CFLAGS}
 

--- a/src/rijndael/Makefile.in
+++ b/src/rijndael/Makefile.in
@@ -170,9 +170,8 @@ rijndael_OBJECTS = $(am_rijndael_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_RIJNDAEL_TRUE@rijndael_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_RIJNDAEL_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_RIJNDAEL_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_RIJNDAEL_TRUE@	librijndael.la \
 @ENABLED_BENCHMARK_RIJNDAEL_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_RIJNDAEL_TRUE@	librijndael.la \
 @ENABLED_BENCHMARK_RIJNDAEL_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_RIJNDAEL_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_RIJNDAEL_TRUE@	$(am__DEPENDENCIES_1)
@@ -387,8 +386,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_RIJNDAEL_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_RIJNDAEL_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_RIJNDAEL_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_RIJNDAEL_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -398,9 +395,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_RIJNDAEL_TRUE@rijndael_SOURCES = 
 @ENABLED_BENCHMARK_RIJNDAEL_TRUE@librijndael_la_SOURCES = aes.c aes.h aestab.h aesxam.c
 @ENABLED_BENCHMARK_RIJNDAEL_TRUE@rijndael_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_RIJNDAEL_TRUE@                         $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_RIJNDAEL_TRUE@                         librijndael.la \
 @ENABLED_BENCHMARK_RIJNDAEL_TRUE@                         $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_RIJNDAEL_TRUE@                         librijndael.la \
 @ENABLED_BENCHMARK_RIJNDAEL_TRUE@                         $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 @ENABLED_BENCHMARK_RIJNDAEL_TRUE@rijndael_CFLAGS = -fno-strict-aliasing ${AM_CFLAGS}

--- a/src/select/Makefile.am
+++ b/src/select/Makefile.am
@@ -32,9 +32,8 @@ select_SOURCES       =
 libselect_la_SOURCES = libselect.c
 
 select_LDADD         = $(DUMMY_CRT0) \
-                       $(top_builddir)/support/libmain.la \
-                       libselect.la \
                        $(top_builddir)/support/libsupport.la \
+                       libselect.la \
                        $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 endif

--- a/src/select/Makefile.in
+++ b/src/select/Makefile.in
@@ -169,9 +169,8 @@ select_OBJECTS = $(am_select_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_SELECT_TRUE@select_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_SELECT_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_SELECT_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_SELECT_TRUE@	libselect.la \
 @ENABLED_BENCHMARK_SELECT_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_SELECT_TRUE@	libselect.la \
 @ENABLED_BENCHMARK_SELECT_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_SELECT_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_SELECT_TRUE@	$(am__DEPENDENCIES_1)
@@ -383,8 +382,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_SELECT_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_SELECT_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_SELECT_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_SELECT_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -394,9 +391,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_SELECT_TRUE@select_SOURCES = 
 @ENABLED_BENCHMARK_SELECT_TRUE@libselect_la_SOURCES = libselect.c
 @ENABLED_BENCHMARK_SELECT_TRUE@select_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_SELECT_TRUE@                       $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_SELECT_TRUE@                       libselect.la \
 @ENABLED_BENCHMARK_SELECT_TRUE@                       $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_SELECT_TRUE@                       libselect.la \
 @ENABLED_BENCHMARK_SELECT_TRUE@                       $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/sglib-arraybinsearch/Makefile.am
+++ b/src/sglib-arraybinsearch/Makefile.am
@@ -32,9 +32,8 @@ sglib_arraybinsearch_SOURCES       =
 libsglib_arraybinsearch_la_SOURCES = arraybinsearch.c sglib.h
 
 sglib_arraybinsearch_LDADD         = $(DUMMY_CRT0) \
-                                     $(top_builddir)/support/libmain.la \
-                                     libsglib-arraybinsearch.la \
                                      $(top_builddir)/support/libsupport.la \
+                                     libsglib-arraybinsearch.la \
                                      $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 endif

--- a/src/sglib-arraybinsearch/Makefile.in
+++ b/src/sglib-arraybinsearch/Makefile.in
@@ -169,9 +169,8 @@ am_sglib_arraybinsearch_OBJECTS =
 sglib_arraybinsearch_OBJECTS = $(am_sglib_arraybinsearch_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_SGLIB_ARRAYBINSEARCH_TRUE@sglib_arraybinsearch_DEPENDENCIES = $(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_SGLIB_ARRAYBINSEARCH_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_SGLIB_ARRAYBINSEARCH_TRUE@	libsglib-arraybinsearch.la \
 @ENABLED_BENCHMARK_SGLIB_ARRAYBINSEARCH_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_SGLIB_ARRAYBINSEARCH_TRUE@	libsglib-arraybinsearch.la \
 @ENABLED_BENCHMARK_SGLIB_ARRAYBINSEARCH_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_SGLIB_ARRAYBINSEARCH_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_SGLIB_ARRAYBINSEARCH_TRUE@	$(am__DEPENDENCIES_1)
@@ -385,8 +384,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_SGLIB_ARRAYBINSEARCH_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_SGLIB_ARRAYBINSEARCH_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_SGLIB_ARRAYBINSEARCH_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_SGLIB_ARRAYBINSEARCH_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -396,9 +393,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_SGLIB_ARRAYBINSEARCH_TRUE@sglib_arraybinsearch_SOURCES = 
 @ENABLED_BENCHMARK_SGLIB_ARRAYBINSEARCH_TRUE@libsglib_arraybinsearch_la_SOURCES = arraybinsearch.c sglib.h
 @ENABLED_BENCHMARK_SGLIB_ARRAYBINSEARCH_TRUE@sglib_arraybinsearch_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_SGLIB_ARRAYBINSEARCH_TRUE@                                     $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_SGLIB_ARRAYBINSEARCH_TRUE@                                     libsglib-arraybinsearch.la \
 @ENABLED_BENCHMARK_SGLIB_ARRAYBINSEARCH_TRUE@                                     $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_SGLIB_ARRAYBINSEARCH_TRUE@                                     libsglib-arraybinsearch.la \
 @ENABLED_BENCHMARK_SGLIB_ARRAYBINSEARCH_TRUE@                                     $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/sglib-arrayheapsort/Makefile.am
+++ b/src/sglib-arrayheapsort/Makefile.am
@@ -34,9 +34,8 @@ libsglib_arrayheapsort_la_SOURCES  = arraysort.c sglib.h
 libsglib_arrayheapsort_la_CPPFLAGS = -DHEAP_SORT ${AM_CPPFLAGS}
 
 sglib_arrayheapsort_LDADD          = $(DUMMY_CRT0) \
-                                     $(top_builddir)/support/libmain.la \
-                                     libsglib-arrayheapsort.la \
                                      $(top_builddir)/support/libsupport.la \
+                                     libsglib-arrayheapsort.la \
                                      $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 endif

--- a/src/sglib-arrayheapsort/Makefile.in
+++ b/src/sglib-arrayheapsort/Makefile.in
@@ -169,9 +169,8 @@ am_sglib_arrayheapsort_OBJECTS =
 sglib_arrayheapsort_OBJECTS = $(am_sglib_arrayheapsort_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_SGLIB_ARRAYHEAPSORT_TRUE@sglib_arrayheapsort_DEPENDENCIES = $(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_SGLIB_ARRAYHEAPSORT_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_SGLIB_ARRAYHEAPSORT_TRUE@	libsglib-arrayheapsort.la \
 @ENABLED_BENCHMARK_SGLIB_ARRAYHEAPSORT_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_SGLIB_ARRAYHEAPSORT_TRUE@	libsglib-arrayheapsort.la \
 @ENABLED_BENCHMARK_SGLIB_ARRAYHEAPSORT_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_SGLIB_ARRAYHEAPSORT_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_SGLIB_ARRAYHEAPSORT_TRUE@	$(am__DEPENDENCIES_1)
@@ -385,8 +384,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_SGLIB_ARRAYHEAPSORT_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_SGLIB_ARRAYHEAPSORT_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_SGLIB_ARRAYHEAPSORT_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_SGLIB_ARRAYHEAPSORT_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -397,9 +394,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_SGLIB_ARRAYHEAPSORT_TRUE@libsglib_arrayheapsort_la_SOURCES = arraysort.c sglib.h
 @ENABLED_BENCHMARK_SGLIB_ARRAYHEAPSORT_TRUE@libsglib_arrayheapsort_la_CPPFLAGS = -DHEAP_SORT ${AM_CPPFLAGS}
 @ENABLED_BENCHMARK_SGLIB_ARRAYHEAPSORT_TRUE@sglib_arrayheapsort_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_SGLIB_ARRAYHEAPSORT_TRUE@                                     $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_SGLIB_ARRAYHEAPSORT_TRUE@                                     libsglib-arrayheapsort.la \
 @ENABLED_BENCHMARK_SGLIB_ARRAYHEAPSORT_TRUE@                                     $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_SGLIB_ARRAYHEAPSORT_TRUE@                                     libsglib-arrayheapsort.la \
 @ENABLED_BENCHMARK_SGLIB_ARRAYHEAPSORT_TRUE@                                     $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/sglib-arrayquicksort/Makefile.am
+++ b/src/sglib-arrayquicksort/Makefile.am
@@ -34,9 +34,8 @@ libsglib_arrayquicksort_la_SOURCES  = arraysort.c sglib.h
 libsglib_arrayquicksort_la_CPPFLAGS = -DQUICK_SORT ${AM_CPPFLAGS}
 
 sglib_arrayquicksort_LDADD          = $(DUMMY_CRT0) \
-                                      $(top_builddir)/support/libmain.la \
-                                      libsglib-arrayquicksort.la \
                                       $(top_builddir)/support/libsupport.la \
+                                      libsglib-arrayquicksort.la \
                                       $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 endif

--- a/src/sglib-arrayquicksort/Makefile.in
+++ b/src/sglib-arrayquicksort/Makefile.in
@@ -169,9 +169,8 @@ am_sglib_arrayquicksort_OBJECTS =
 sglib_arrayquicksort_OBJECTS = $(am_sglib_arrayquicksort_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_SGLIB_ARRAYQUICKSORT_TRUE@sglib_arrayquicksort_DEPENDENCIES = $(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_SGLIB_ARRAYQUICKSORT_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_SGLIB_ARRAYQUICKSORT_TRUE@	libsglib-arrayquicksort.la \
 @ENABLED_BENCHMARK_SGLIB_ARRAYQUICKSORT_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_SGLIB_ARRAYQUICKSORT_TRUE@	libsglib-arrayquicksort.la \
 @ENABLED_BENCHMARK_SGLIB_ARRAYQUICKSORT_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_SGLIB_ARRAYQUICKSORT_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_SGLIB_ARRAYQUICKSORT_TRUE@	$(am__DEPENDENCIES_1)
@@ -385,8 +384,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_SGLIB_ARRAYQUICKSORT_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_SGLIB_ARRAYQUICKSORT_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_SGLIB_ARRAYQUICKSORT_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_SGLIB_ARRAYQUICKSORT_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -397,9 +394,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_SGLIB_ARRAYQUICKSORT_TRUE@libsglib_arrayquicksort_la_SOURCES = arraysort.c sglib.h
 @ENABLED_BENCHMARK_SGLIB_ARRAYQUICKSORT_TRUE@libsglib_arrayquicksort_la_CPPFLAGS = -DQUICK_SORT ${AM_CPPFLAGS}
 @ENABLED_BENCHMARK_SGLIB_ARRAYQUICKSORT_TRUE@sglib_arrayquicksort_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_SGLIB_ARRAYQUICKSORT_TRUE@                                      $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_SGLIB_ARRAYQUICKSORT_TRUE@                                      libsglib-arrayquicksort.la \
 @ENABLED_BENCHMARK_SGLIB_ARRAYQUICKSORT_TRUE@                                      $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_SGLIB_ARRAYQUICKSORT_TRUE@                                      libsglib-arrayquicksort.la \
 @ENABLED_BENCHMARK_SGLIB_ARRAYQUICKSORT_TRUE@                                      $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/sglib-dllist/Makefile.am
+++ b/src/sglib-dllist/Makefile.am
@@ -32,9 +32,8 @@ sglib_dllist_SOURCES       =
 libsglib_dllist_la_SOURCES = dllist.c sglib.h
 
 sglib_dllist_LDADD         = $(DUMMY_CRT0) \
-                             $(top_builddir)/support/libmain.la \
-                             libsglib-dllist.la \
                              $(top_builddir)/support/libsupport.la \
+                             libsglib-dllist.la \
                              $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/sglib-dllist/Makefile.in
+++ b/src/sglib-dllist/Makefile.in
@@ -171,9 +171,8 @@ sglib_dllist_OBJECTS = $(am_sglib_dllist_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_SGLIB_DLLIST_TRUE@sglib_dllist_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_SGLIB_DLLIST_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_SGLIB_DLLIST_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_SGLIB_DLLIST_TRUE@	libsglib-dllist.la \
 @ENABLED_BENCHMARK_SGLIB_DLLIST_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_SGLIB_DLLIST_TRUE@	libsglib-dllist.la \
 @ENABLED_BENCHMARK_SGLIB_DLLIST_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_SGLIB_DLLIST_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_SGLIB_DLLIST_TRUE@	$(am__DEPENDENCIES_1)
@@ -386,8 +385,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_SGLIB_DLLIST_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_SGLIB_DLLIST_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_SGLIB_DLLIST_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_SGLIB_DLLIST_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -397,9 +394,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_SGLIB_DLLIST_TRUE@sglib_dllist_SOURCES = 
 @ENABLED_BENCHMARK_SGLIB_DLLIST_TRUE@libsglib_dllist_la_SOURCES = dllist.c sglib.h
 @ENABLED_BENCHMARK_SGLIB_DLLIST_TRUE@sglib_dllist_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_SGLIB_DLLIST_TRUE@                             $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_SGLIB_DLLIST_TRUE@                             libsglib-dllist.la \
 @ENABLED_BENCHMARK_SGLIB_DLLIST_TRUE@                             $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_SGLIB_DLLIST_TRUE@                             libsglib-dllist.la \
 @ENABLED_BENCHMARK_SGLIB_DLLIST_TRUE@                             $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/sglib-hashtable/Makefile.am
+++ b/src/sglib-hashtable/Makefile.am
@@ -32,9 +32,8 @@ sglib_hashtable_SOURCES       =
 libsglib_hashtable_la_SOURCES = hashtable.c sglib.h
 
 sglib_hashtable_LDADD         = $(DUMMY_CRT0) \
-                                $(top_builddir)/support/libmain.la \
-                                libsglib-hashtable.la \
                                 $(top_builddir)/support/libsupport.la \
+                                libsglib-hashtable.la \
                                 $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/sglib-hashtable/Makefile.in
+++ b/src/sglib-hashtable/Makefile.in
@@ -170,9 +170,8 @@ sglib_hashtable_OBJECTS = $(am_sglib_hashtable_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_SGLIB_HASHTABLE_TRUE@sglib_hashtable_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_SGLIB_HASHTABLE_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_SGLIB_HASHTABLE_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_SGLIB_HASHTABLE_TRUE@	libsglib-hashtable.la \
 @ENABLED_BENCHMARK_SGLIB_HASHTABLE_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_SGLIB_HASHTABLE_TRUE@	libsglib-hashtable.la \
 @ENABLED_BENCHMARK_SGLIB_HASHTABLE_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_SGLIB_HASHTABLE_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_SGLIB_HASHTABLE_TRUE@	$(am__DEPENDENCIES_1)
@@ -385,8 +384,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_SGLIB_HASHTABLE_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_SGLIB_HASHTABLE_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_SGLIB_HASHTABLE_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_SGLIB_HASHTABLE_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -396,9 +393,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_SGLIB_HASHTABLE_TRUE@sglib_hashtable_SOURCES = 
 @ENABLED_BENCHMARK_SGLIB_HASHTABLE_TRUE@libsglib_hashtable_la_SOURCES = hashtable.c sglib.h
 @ENABLED_BENCHMARK_SGLIB_HASHTABLE_TRUE@sglib_hashtable_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_SGLIB_HASHTABLE_TRUE@                                $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_SGLIB_HASHTABLE_TRUE@                                libsglib-hashtable.la \
 @ENABLED_BENCHMARK_SGLIB_HASHTABLE_TRUE@                                $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_SGLIB_HASHTABLE_TRUE@                                libsglib-hashtable.la \
 @ENABLED_BENCHMARK_SGLIB_HASHTABLE_TRUE@                                $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/sglib-listinsertsort/Makefile.am
+++ b/src/sglib-listinsertsort/Makefile.am
@@ -37,9 +37,8 @@ sglib_listinsertsort_SOURCES       =
 libsglib_listinsertsort_la_SOURCES = listinsertsort.c sglib.h
 
 sglib_listinsertsort_LDADD         = $(DUMMY_CRT0) \
-                                     $(top_builddir)/support/libmain.la \
-                                     libsglib-listinsertsort.la \
                                      $(top_builddir)/support/libsupport.la \
+                                     libsglib-listinsertsort.la \
                                      $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/sglib-listinsertsort/Makefile.in
+++ b/src/sglib-listinsertsort/Makefile.in
@@ -173,9 +173,8 @@ am_sglib_listinsertsort_OBJECTS =
 sglib_listinsertsort_OBJECTS = $(am_sglib_listinsertsort_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_SGLIB_LISTINSERTSORT_TRUE@sglib_listinsertsort_DEPENDENCIES = $(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_SGLIB_LISTINSERTSORT_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_SGLIB_LISTINSERTSORT_TRUE@	libsglib-listinsertsort.la \
 @ENABLED_BENCHMARK_SGLIB_LISTINSERTSORT_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_SGLIB_LISTINSERTSORT_TRUE@	libsglib-listinsertsort.la \
 @ENABLED_BENCHMARK_SGLIB_LISTINSERTSORT_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_SGLIB_LISTINSERTSORT_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_SGLIB_LISTINSERTSORT_TRUE@	$(am__DEPENDENCIES_1)
@@ -389,8 +388,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_SGLIB_LISTINSERTSORT_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_SGLIB_LISTINSERTSORT_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_SGLIB_LISTINSERTSORT_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_SGLIB_LISTINSERTSORT_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -400,9 +397,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_SGLIB_LISTINSERTSORT_TRUE@sglib_listinsertsort_SOURCES = 
 @ENABLED_BENCHMARK_SGLIB_LISTINSERTSORT_TRUE@libsglib_listinsertsort_la_SOURCES = listinsertsort.c sglib.h
 @ENABLED_BENCHMARK_SGLIB_LISTINSERTSORT_TRUE@sglib_listinsertsort_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_SGLIB_LISTINSERTSORT_TRUE@                                     $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_SGLIB_LISTINSERTSORT_TRUE@                                     libsglib-listinsertsort.la \
 @ENABLED_BENCHMARK_SGLIB_LISTINSERTSORT_TRUE@                                     $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_SGLIB_LISTINSERTSORT_TRUE@                                     libsglib-listinsertsort.la \
 @ENABLED_BENCHMARK_SGLIB_LISTINSERTSORT_TRUE@                                     $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/sglib-listsort/Makefile.am
+++ b/src/sglib-listsort/Makefile.am
@@ -32,9 +32,8 @@ sglib_listsort_SOURCES       =
 libsglib_listsort_la_SOURCES = listsort.c sglib.h
 
 sglib_listsort_LDADD         = $(DUMMY_CRT0) \
-                               $(top_builddir)/support/libmain.la \
-                               libsglib-listsort.la \
                                $(top_builddir)/support/libsupport.la \
+                               libsglib-listsort.la \
                                $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/sglib-listsort/Makefile.in
+++ b/src/sglib-listsort/Makefile.in
@@ -170,9 +170,8 @@ sglib_listsort_OBJECTS = $(am_sglib_listsort_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_SGLIB_LISTSORT_TRUE@sglib_listsort_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_SGLIB_LISTSORT_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_SGLIB_LISTSORT_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_SGLIB_LISTSORT_TRUE@	libsglib-listsort.la \
 @ENABLED_BENCHMARK_SGLIB_LISTSORT_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_SGLIB_LISTSORT_TRUE@	libsglib-listsort.la \
 @ENABLED_BENCHMARK_SGLIB_LISTSORT_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_SGLIB_LISTSORT_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_SGLIB_LISTSORT_TRUE@	$(am__DEPENDENCIES_1)
@@ -385,8 +384,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_SGLIB_LISTSORT_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_SGLIB_LISTSORT_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_SGLIB_LISTSORT_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_SGLIB_LISTSORT_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -396,9 +393,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_SGLIB_LISTSORT_TRUE@sglib_listsort_SOURCES = 
 @ENABLED_BENCHMARK_SGLIB_LISTSORT_TRUE@libsglib_listsort_la_SOURCES = listsort.c sglib.h
 @ENABLED_BENCHMARK_SGLIB_LISTSORT_TRUE@sglib_listsort_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_SGLIB_LISTSORT_TRUE@                               $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_SGLIB_LISTSORT_TRUE@                               libsglib-listsort.la \
 @ENABLED_BENCHMARK_SGLIB_LISTSORT_TRUE@                               $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_SGLIB_LISTSORT_TRUE@                               libsglib-listsort.la \
 @ENABLED_BENCHMARK_SGLIB_LISTSORT_TRUE@                               $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/sglib-queue/Makefile.am
+++ b/src/sglib-queue/Makefile.am
@@ -32,9 +32,8 @@ sglib_queue_SOURCES       =
 libsglib_queue_la_SOURCES = queue.c sglib.h
 
 sglib_queue_LDADD         = $(DUMMY_CRT0) \
-                            $(top_builddir)/support/libmain.la \
-                            libsglib-queue.la \
                             $(top_builddir)/support/libsupport.la \
+                            libsglib-queue.la \
                             $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/sglib-queue/Makefile.in
+++ b/src/sglib-queue/Makefile.in
@@ -171,9 +171,8 @@ sglib_queue_OBJECTS = $(am_sglib_queue_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_SGLIB_QUEUE_TRUE@sglib_queue_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_SGLIB_QUEUE_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_SGLIB_QUEUE_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_SGLIB_QUEUE_TRUE@	libsglib-queue.la \
 @ENABLED_BENCHMARK_SGLIB_QUEUE_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_SGLIB_QUEUE_TRUE@	libsglib-queue.la \
 @ENABLED_BENCHMARK_SGLIB_QUEUE_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_SGLIB_QUEUE_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_SGLIB_QUEUE_TRUE@	$(am__DEPENDENCIES_1)
@@ -386,8 +385,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_SGLIB_QUEUE_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_SGLIB_QUEUE_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_SGLIB_QUEUE_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_SGLIB_QUEUE_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -397,9 +394,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_SGLIB_QUEUE_TRUE@sglib_queue_SOURCES = 
 @ENABLED_BENCHMARK_SGLIB_QUEUE_TRUE@libsglib_queue_la_SOURCES = queue.c sglib.h
 @ENABLED_BENCHMARK_SGLIB_QUEUE_TRUE@sglib_queue_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_SGLIB_QUEUE_TRUE@                            $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_SGLIB_QUEUE_TRUE@                            libsglib-queue.la \
 @ENABLED_BENCHMARK_SGLIB_QUEUE_TRUE@                            $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_SGLIB_QUEUE_TRUE@                            libsglib-queue.la \
 @ENABLED_BENCHMARK_SGLIB_QUEUE_TRUE@                            $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/sglib-rbtree/Makefile.am
+++ b/src/sglib-rbtree/Makefile.am
@@ -32,9 +32,8 @@ sglib_rbtree_SOURCES       =
 libsglib_rbtree_la_SOURCES = rbtree.c sglib.h
 
 sglib_rbtree_LDADD         = $(DUMMY_CRT0) \
-                             $(top_builddir)/support/libmain.la \
-                             libsglib-rbtree.la \
                              $(top_builddir)/support/libsupport.la \
+                             libsglib-rbtree.la \
                              $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/sglib-rbtree/Makefile.in
+++ b/src/sglib-rbtree/Makefile.in
@@ -171,9 +171,8 @@ sglib_rbtree_OBJECTS = $(am_sglib_rbtree_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_SGLIB_RBTREE_TRUE@sglib_rbtree_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_SGLIB_RBTREE_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_SGLIB_RBTREE_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_SGLIB_RBTREE_TRUE@	libsglib-rbtree.la \
 @ENABLED_BENCHMARK_SGLIB_RBTREE_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_SGLIB_RBTREE_TRUE@	libsglib-rbtree.la \
 @ENABLED_BENCHMARK_SGLIB_RBTREE_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_SGLIB_RBTREE_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_SGLIB_RBTREE_TRUE@	$(am__DEPENDENCIES_1)
@@ -386,8 +385,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_SGLIB_RBTREE_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_SGLIB_RBTREE_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_SGLIB_RBTREE_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_SGLIB_RBTREE_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -397,9 +394,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_SGLIB_RBTREE_TRUE@sglib_rbtree_SOURCES = 
 @ENABLED_BENCHMARK_SGLIB_RBTREE_TRUE@libsglib_rbtree_la_SOURCES = rbtree.c sglib.h
 @ENABLED_BENCHMARK_SGLIB_RBTREE_TRUE@sglib_rbtree_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_SGLIB_RBTREE_TRUE@                             $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_SGLIB_RBTREE_TRUE@                             libsglib-rbtree.la \
 @ENABLED_BENCHMARK_SGLIB_RBTREE_TRUE@                             $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_SGLIB_RBTREE_TRUE@                             libsglib-rbtree.la \
 @ENABLED_BENCHMARK_SGLIB_RBTREE_TRUE@                             $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/slre/Makefile.am
+++ b/src/slre/Makefile.am
@@ -32,9 +32,8 @@ slre_SOURCES       =
 libslre_la_SOURCES = libslre.c slre.h
 
 slre_LDADD         = $(DUMMY_CRT0) \
-                     $(top_builddir)/support/libmain.la \
-                     libslre.la \
                      $(top_builddir)/support/libsupport.la \
+                     libslre.la \
                      $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/slre/Makefile.in
+++ b/src/slre/Makefile.in
@@ -169,10 +169,8 @@ slre_OBJECTS = $(am_slre_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_SLRE_TRUE@slre_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_SLRE_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_SLRE_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_SLRE_TRUE@	libslre.la \
 @ENABLED_BENCHMARK_SLRE_TRUE@	$(top_builddir)/support/libsupport.la \
-@ENABLED_BENCHMARK_SLRE_TRUE@	$(am__DEPENDENCIES_1) \
+@ENABLED_BENCHMARK_SLRE_TRUE@	libslre.la $(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_SLRE_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_SLRE_TRUE@	$(am__DEPENDENCIES_1)
 AM_V_P = $(am__v_P_@AM_V@)
@@ -383,8 +381,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_SLRE_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_SLRE_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_SLRE_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_SLRE_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -394,9 +390,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_SLRE_TRUE@slre_SOURCES = 
 @ENABLED_BENCHMARK_SLRE_TRUE@libslre_la_SOURCES = libslre.c slre.h
 @ENABLED_BENCHMARK_SLRE_TRUE@slre_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_SLRE_TRUE@                     $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_SLRE_TRUE@                     libslre.la \
 @ENABLED_BENCHMARK_SLRE_TRUE@                     $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_SLRE_TRUE@                     libslre.la \
 @ENABLED_BENCHMARK_SLRE_TRUE@                     $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/sqrt/Makefile.am
+++ b/src/sqrt/Makefile.am
@@ -32,9 +32,8 @@ sqrt_SOURCES       =
 libsqrt_la_SOURCES = libsqrt.c
 
 sqrt_LDADD         = $(DUMMY_CRT0) \
-                     $(top_builddir)/support/libmain.la \
-                     libsqrt.la \
                      $(top_builddir)/support/libsupport.la \
+                     libsqrt.la \
                      $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/sqrt/Makefile.in
+++ b/src/sqrt/Makefile.in
@@ -169,10 +169,8 @@ sqrt_OBJECTS = $(am_sqrt_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_SQRT_TRUE@sqrt_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_SQRT_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_SQRT_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_SQRT_TRUE@	libsqrt.la \
 @ENABLED_BENCHMARK_SQRT_TRUE@	$(top_builddir)/support/libsupport.la \
-@ENABLED_BENCHMARK_SQRT_TRUE@	$(am__DEPENDENCIES_1) \
+@ENABLED_BENCHMARK_SQRT_TRUE@	libsqrt.la $(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_SQRT_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_SQRT_TRUE@	$(am__DEPENDENCIES_1)
 AM_V_P = $(am__v_P_@AM_V@)
@@ -383,8 +381,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_SQRT_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_SQRT_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_SQRT_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_SQRT_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -394,9 +390,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_SQRT_TRUE@sqrt_SOURCES = 
 @ENABLED_BENCHMARK_SQRT_TRUE@libsqrt_la_SOURCES = libsqrt.c
 @ENABLED_BENCHMARK_SQRT_TRUE@sqrt_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_SQRT_TRUE@                     $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_SQRT_TRUE@                     libsqrt.la \
 @ENABLED_BENCHMARK_SQRT_TRUE@                     $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_SQRT_TRUE@                     libsqrt.la \
 @ENABLED_BENCHMARK_SQRT_TRUE@                     $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/st/Makefile.am
+++ b/src/st/Makefile.am
@@ -32,9 +32,8 @@ st_SOURCES         =
 libst_la_SOURCES = libst.c
 
 st_LDADD           = $(DUMMY_CRT0) \
-                     $(top_builddir)/support/libmain.la \
-                     libst.la \
                      $(top_builddir)/support/libsupport.la \
+                     libst.la \
                      $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT) \
                      $(LIBM)
 

--- a/src/st/Makefile.in
+++ b/src/st/Makefile.in
@@ -168,10 +168,8 @@ am_st_OBJECTS =
 st_OBJECTS = $(am_st_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_ST_TRUE@st_DEPENDENCIES = $(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_ST_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_ST_TRUE@	libst.la \
 @ENABLED_BENCHMARK_ST_TRUE@	$(top_builddir)/support/libsupport.la \
-@ENABLED_BENCHMARK_ST_TRUE@	$(am__DEPENDENCIES_1) \
+@ENABLED_BENCHMARK_ST_TRUE@	libst.la $(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_ST_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_ST_TRUE@	$(am__DEPENDENCIES_1) $(LIBM)
 AM_V_P = $(am__v_P_@AM_V@)
@@ -382,8 +380,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_ST_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_ST_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_ST_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_ST_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -393,9 +389,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_ST_TRUE@st_SOURCES = 
 @ENABLED_BENCHMARK_ST_TRUE@libst_la_SOURCES = libst.c
 @ENABLED_BENCHMARK_ST_TRUE@st_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_ST_TRUE@                     $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_ST_TRUE@                     libst.la \
 @ENABLED_BENCHMARK_ST_TRUE@                     $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_ST_TRUE@                     libst.la \
 @ENABLED_BENCHMARK_ST_TRUE@                     $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT) \
 @ENABLED_BENCHMARK_ST_TRUE@                     $(LIBM)
 

--- a/src/statemate/Makefile.am
+++ b/src/statemate/Makefile.am
@@ -32,9 +32,8 @@ statemate_SOURCES       =
 libstatemate_la_SOURCES = libstatemate.c
 
 statemate_LDADD         = $(DUMMY_CRT0) \
-                          $(top_builddir)/support/libmain.la \
-                          libstatemate.la \
                           $(top_builddir)/support/libsupport.la \
+                          libstatemate.la \
                           $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/statemate/Makefile.in
+++ b/src/statemate/Makefile.in
@@ -170,9 +170,8 @@ statemate_OBJECTS = $(am_statemate_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_STATEMATE_TRUE@statemate_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_STATEMATE_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_STATEMATE_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_STATEMATE_TRUE@	libstatemate.la \
 @ENABLED_BENCHMARK_STATEMATE_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_STATEMATE_TRUE@	libstatemate.la \
 @ENABLED_BENCHMARK_STATEMATE_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_STATEMATE_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_STATEMATE_TRUE@	$(am__DEPENDENCIES_1)
@@ -385,8 +384,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_STATEMATE_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_STATEMATE_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_STATEMATE_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_STATEMATE_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -396,9 +393,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_STATEMATE_TRUE@statemate_SOURCES = 
 @ENABLED_BENCHMARK_STATEMATE_TRUE@libstatemate_la_SOURCES = libstatemate.c
 @ENABLED_BENCHMARK_STATEMATE_TRUE@statemate_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_STATEMATE_TRUE@                          $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_STATEMATE_TRUE@                          libstatemate.la \
 @ENABLED_BENCHMARK_STATEMATE_TRUE@                          $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_STATEMATE_TRUE@                          libstatemate.la \
 @ENABLED_BENCHMARK_STATEMATE_TRUE@                          $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/stb_perlin/Makefile.am
+++ b/src/stb_perlin/Makefile.am
@@ -32,9 +32,8 @@ stb_perlin_SOURCES       =
 libstb_perlin_la_SOURCES = libstb_perlin.c
 
 stb_perlin_LDADD         = $(DUMMY_CRT0) \
-                           $(top_builddir)/support/libmain.la \
-                           libstb_perlin.la \
                            $(top_builddir)/support/libsupport.la \
+                           libstb_perlin.la \
                            $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT) \
                            $(LIBM)
 

--- a/src/stb_perlin/Makefile.in
+++ b/src/stb_perlin/Makefile.in
@@ -170,9 +170,8 @@ stb_perlin_OBJECTS = $(am_stb_perlin_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_STB_PERLIN_TRUE@stb_perlin_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_STB_PERLIN_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_STB_PERLIN_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_STB_PERLIN_TRUE@	libstb_perlin.la \
 @ENABLED_BENCHMARK_STB_PERLIN_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_STB_PERLIN_TRUE@	libstb_perlin.la \
 @ENABLED_BENCHMARK_STB_PERLIN_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_STB_PERLIN_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_STB_PERLIN_TRUE@	$(am__DEPENDENCIES_1) \
@@ -386,8 +385,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_STB_PERLIN_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_STB_PERLIN_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_STB_PERLIN_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_STB_PERLIN_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -397,9 +394,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_STB_PERLIN_TRUE@stb_perlin_SOURCES = 
 @ENABLED_BENCHMARK_STB_PERLIN_TRUE@libstb_perlin_la_SOURCES = libstb_perlin.c
 @ENABLED_BENCHMARK_STB_PERLIN_TRUE@stb_perlin_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_STB_PERLIN_TRUE@                           $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_STB_PERLIN_TRUE@                           libstb_perlin.la \
 @ENABLED_BENCHMARK_STB_PERLIN_TRUE@                           $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_STB_PERLIN_TRUE@                           libstb_perlin.la \
 @ENABLED_BENCHMARK_STB_PERLIN_TRUE@                           $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT) \
 @ENABLED_BENCHMARK_STB_PERLIN_TRUE@                           $(LIBM)
 

--- a/src/stringsearch1/Makefile.am
+++ b/src/stringsearch1/Makefile.am
@@ -32,9 +32,8 @@ stringsearch1_SOURCES       =
 libstringsearch1_la_SOURCES = stringsearch1.c fast.fwd.inc.c fast.rev.d12.c
 
 stringsearch1_LDADD         = $(DUMMY_CRT0) \
-                              $(top_builddir)/support/libmain.la \
-                              libstringsearch1.la \
                               $(top_builddir)/support/libsupport.la \
+                              libstringsearch1.la \
                               $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 endif

--- a/src/stringsearch1/Makefile.in
+++ b/src/stringsearch1/Makefile.in
@@ -174,9 +174,8 @@ stringsearch1_OBJECTS = $(am_stringsearch1_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_STRINGSEARCH1_TRUE@stringsearch1_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_STRINGSEARCH1_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_STRINGSEARCH1_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_STRINGSEARCH1_TRUE@	libstringsearch1.la \
 @ENABLED_BENCHMARK_STRINGSEARCH1_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_STRINGSEARCH1_TRUE@	libstringsearch1.la \
 @ENABLED_BENCHMARK_STRINGSEARCH1_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_STRINGSEARCH1_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_STRINGSEARCH1_TRUE@	$(am__DEPENDENCIES_1)
@@ -389,8 +388,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_STRINGSEARCH1_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_STRINGSEARCH1_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_STRINGSEARCH1_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_STRINGSEARCH1_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -400,9 +397,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_STRINGSEARCH1_TRUE@stringsearch1_SOURCES = 
 @ENABLED_BENCHMARK_STRINGSEARCH1_TRUE@libstringsearch1_la_SOURCES = stringsearch1.c fast.fwd.inc.c fast.rev.d12.c
 @ENABLED_BENCHMARK_STRINGSEARCH1_TRUE@stringsearch1_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_STRINGSEARCH1_TRUE@                              $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_STRINGSEARCH1_TRUE@                              libstringsearch1.la \
 @ENABLED_BENCHMARK_STRINGSEARCH1_TRUE@                              $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_STRINGSEARCH1_TRUE@                              libstringsearch1.la \
 @ENABLED_BENCHMARK_STRINGSEARCH1_TRUE@                              $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/strstr/Makefile.am
+++ b/src/strstr/Makefile.am
@@ -32,9 +32,8 @@ strstr_SOURCES       =
 libstrstr_la_SOURCES = libstrstr.c
 
 strstr_LDADD         = $(DUMMY_CRT0) \
-                       $(top_builddir)/support/libmain.la \
-                       libstrstr.la \
                        $(top_builddir)/support/libsupport.la \
+                       libstrstr.la \
                        $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/strstr/Makefile.in
+++ b/src/strstr/Makefile.in
@@ -169,9 +169,8 @@ strstr_OBJECTS = $(am_strstr_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_STRSTR_TRUE@strstr_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_STRSTR_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_STRSTR_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_STRSTR_TRUE@	libstrstr.la \
 @ENABLED_BENCHMARK_STRSTR_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_STRSTR_TRUE@	libstrstr.la \
 @ENABLED_BENCHMARK_STRSTR_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_STRSTR_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_STRSTR_TRUE@	$(am__DEPENDENCIES_1)
@@ -383,8 +382,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_STRSTR_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_STRSTR_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_STRSTR_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_STRSTR_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -394,9 +391,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_STRSTR_TRUE@strstr_SOURCES = 
 @ENABLED_BENCHMARK_STRSTR_TRUE@libstrstr_la_SOURCES = libstrstr.c
 @ENABLED_BENCHMARK_STRSTR_TRUE@strstr_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_STRSTR_TRUE@                       $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_STRSTR_TRUE@                       libstrstr.la \
 @ENABLED_BENCHMARK_STRSTR_TRUE@                       $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_STRSTR_TRUE@                       libstrstr.la \
 @ENABLED_BENCHMARK_STRSTR_TRUE@                       $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/tarai/Makefile.am
+++ b/src/tarai/Makefile.am
@@ -32,9 +32,8 @@ tarai_SOURCES       =
 libtarai_la_SOURCES = libtarai.c
 
 tarai_LDADD         = $(DUMMY_CRT0) \
-                      $(top_builddir)/support/libmain.la \
-                      libtarai.la \
                       $(top_builddir)/support/libsupport.la \
+                      libtarai.la \
                       $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/tarai/Makefile.in
+++ b/src/tarai/Makefile.in
@@ -169,9 +169,8 @@ tarai_OBJECTS = $(am_tarai_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_TARAI_TRUE@tarai_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_TARAI_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_TARAI_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_TARAI_TRUE@	libtarai.la \
 @ENABLED_BENCHMARK_TARAI_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_TARAI_TRUE@	libtarai.la \
 @ENABLED_BENCHMARK_TARAI_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_TARAI_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_TARAI_TRUE@	$(am__DEPENDENCIES_1)
@@ -383,8 +382,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_TARAI_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_TARAI_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_TARAI_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_TARAI_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -394,9 +391,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_TARAI_TRUE@tarai_SOURCES = 
 @ENABLED_BENCHMARK_TARAI_TRUE@libtarai_la_SOURCES = libtarai.c
 @ENABLED_BENCHMARK_TARAI_TRUE@tarai_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_TARAI_TRUE@                      $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_TARAI_TRUE@                      libtarai.la \
 @ENABLED_BENCHMARK_TARAI_TRUE@                      $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_TARAI_TRUE@                      libtarai.la \
 @ENABLED_BENCHMARK_TARAI_TRUE@                      $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/template/Makefile.am
+++ b/src/template/Makefile.am
@@ -44,9 +44,8 @@ template_SOURCES       =
 libtemplate_la_SOURCES = libtemplate.c
 
 template_LDADD         = $(DUMMY_CRT0) \
-                         $(top_builddir)/support/libmain.la \
-                         libtemplate.la \
                          $(top_builddir)/support/libsupport.la \
+                         libtemplate.la \
                          $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/template/Makefile.in
+++ b/src/template/Makefile.in
@@ -181,9 +181,8 @@ template_OBJECTS = $(am_template_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_TEMPLATE_TRUE@template_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_TEMPLATE_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_TEMPLATE_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_TEMPLATE_TRUE@	libtemplate.la \
 @ENABLED_BENCHMARK_TEMPLATE_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_TEMPLATE_TRUE@	libtemplate.la \
 @ENABLED_BENCHMARK_TEMPLATE_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_TEMPLATE_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_TEMPLATE_TRUE@	$(am__DEPENDENCIES_1)
@@ -395,8 +394,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_TEMPLATE_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_TEMPLATE_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_TEMPLATE_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_TEMPLATE_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -406,9 +403,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_TEMPLATE_TRUE@template_SOURCES = 
 @ENABLED_BENCHMARK_TEMPLATE_TRUE@libtemplate_la_SOURCES = libtemplate.c
 @ENABLED_BENCHMARK_TEMPLATE_TRUE@template_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_TEMPLATE_TRUE@                         $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_TEMPLATE_TRUE@                         libtemplate.la \
 @ENABLED_BENCHMARK_TEMPLATE_TRUE@                         $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_TEMPLATE_TRUE@                         libtemplate.la \
 @ENABLED_BENCHMARK_TEMPLATE_TRUE@                         $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/trio-snprintf/Makefile.am
+++ b/src/trio-snprintf/Makefile.am
@@ -34,9 +34,8 @@ libtrio_snprintf_la_SOURCES  = trio.c trio.h trio_test.c triostr.c triostr.h \
                                triodef.h triop.h
 
 trio_snprintf_LDADD          = $(DUMMY_CRT0) \
-                               $(top_builddir)/support/libmain.la \
-                               libtrio-snprintf.la \
                                $(top_builddir)/support/libsupport.la \
+                               libtrio-snprintf.la \
                                $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 libtrio_snprintf_la_CPPFLAGS = -DTRIO_EXTENSION=0 -DTRIO_DEPRECATED=0 \
                                -DTRIO_MICROSOFT=0 -DTRIO_ERRORS=0     \

--- a/src/trio-snprintf/Makefile.in
+++ b/src/trio-snprintf/Makefile.in
@@ -173,9 +173,8 @@ trio_snprintf_OBJECTS = $(am_trio_snprintf_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_TRIO_SNPRINTF_TRUE@trio_snprintf_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_TRIO_SNPRINTF_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_TRIO_SNPRINTF_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_TRIO_SNPRINTF_TRUE@	libtrio-snprintf.la \
 @ENABLED_BENCHMARK_TRIO_SNPRINTF_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_TRIO_SNPRINTF_TRUE@	libtrio-snprintf.la \
 @ENABLED_BENCHMARK_TRIO_SNPRINTF_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_TRIO_SNPRINTF_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_TRIO_SNPRINTF_TRUE@	$(am__DEPENDENCIES_1)
@@ -388,8 +387,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_TRIO_SNPRINTF_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_TRIO_SNPRINTF_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_TRIO_SNPRINTF_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_TRIO_SNPRINTF_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -401,9 +398,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_TRIO_SNPRINTF_TRUE@                               triodef.h triop.h
 
 @ENABLED_BENCHMARK_TRIO_SNPRINTF_TRUE@trio_snprintf_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_TRIO_SNPRINTF_TRUE@                               $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_TRIO_SNPRINTF_TRUE@                               libtrio-snprintf.la \
 @ENABLED_BENCHMARK_TRIO_SNPRINTF_TRUE@                               $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_TRIO_SNPRINTF_TRUE@                               libtrio-snprintf.la \
 @ENABLED_BENCHMARK_TRIO_SNPRINTF_TRUE@                               $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 @ENABLED_BENCHMARK_TRIO_SNPRINTF_TRUE@libtrio_snprintf_la_CPPFLAGS = -DTRIO_EXTENSION=0 -DTRIO_DEPRECATED=0 \

--- a/src/trio-sscanf/Makefile.am
+++ b/src/trio-sscanf/Makefile.am
@@ -34,9 +34,8 @@ libtrio_sscanf_la_SOURCES  = trio.c trio.h trio_test.c triostr.c triostr.h \
                              triodef.h triop.h
 
 trio_sscanf_LDADD          = $(DUMMY_CRT0) \
-                             $(top_builddir)/support/libmain.la \
-                             libtrio-sscanf.la \
                              $(top_builddir)/support/libsupport.la \
+                             libtrio-sscanf.la \
                              $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 libtrio_sscanf_la_CPPFLAGS = -DTRIO_SSCANF -DTRIO_EXTENSION=0 \
                              -DTRIO_DEPRECATED=0 -DTRIO_MICROSOFT=0 \

--- a/src/trio-sscanf/Makefile.in
+++ b/src/trio-sscanf/Makefile.in
@@ -174,9 +174,8 @@ trio_sscanf_OBJECTS = $(am_trio_sscanf_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_TRIO_SSCANF_TRUE@trio_sscanf_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_TRIO_SSCANF_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_TRIO_SSCANF_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_TRIO_SSCANF_TRUE@	libtrio-sscanf.la \
 @ENABLED_BENCHMARK_TRIO_SSCANF_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_TRIO_SSCANF_TRUE@	libtrio-sscanf.la \
 @ENABLED_BENCHMARK_TRIO_SSCANF_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_TRIO_SSCANF_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_TRIO_SSCANF_TRUE@	$(am__DEPENDENCIES_1)
@@ -389,8 +388,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_TRIO_SSCANF_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_TRIO_SSCANF_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_TRIO_SSCANF_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_TRIO_SSCANF_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -402,9 +399,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_TRIO_SSCANF_TRUE@                             triodef.h triop.h
 
 @ENABLED_BENCHMARK_TRIO_SSCANF_TRUE@trio_sscanf_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_TRIO_SSCANF_TRUE@                             $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_TRIO_SSCANF_TRUE@                             libtrio-sscanf.la \
 @ENABLED_BENCHMARK_TRIO_SSCANF_TRUE@                             $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_TRIO_SSCANF_TRUE@                             libtrio-sscanf.la \
 @ENABLED_BENCHMARK_TRIO_SSCANF_TRUE@                             $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 @ENABLED_BENCHMARK_TRIO_SSCANF_TRUE@libtrio_sscanf_la_CPPFLAGS = -DTRIO_SSCANF -DTRIO_EXTENSION=0 \

--- a/src/ud/Makefile.am
+++ b/src/ud/Makefile.am
@@ -32,9 +32,8 @@ ud_SOURCES         =
 libud_la_SOURCES = libud.c
 
 ud_LDADD           = $(DUMMY_CRT0) \
-                     $(top_builddir)/support/libmain.la \
-                     libud.la \
                      $(top_builddir)/support/libsupport.la \
+                     libud.la \
                      $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 

--- a/src/ud/Makefile.in
+++ b/src/ud/Makefile.in
@@ -168,10 +168,8 @@ am_ud_OBJECTS =
 ud_OBJECTS = $(am_ud_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_UD_TRUE@ud_DEPENDENCIES = $(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_UD_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_UD_TRUE@	libud.la \
 @ENABLED_BENCHMARK_UD_TRUE@	$(top_builddir)/support/libsupport.la \
-@ENABLED_BENCHMARK_UD_TRUE@	$(am__DEPENDENCIES_1) \
+@ENABLED_BENCHMARK_UD_TRUE@	libud.la $(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_UD_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_UD_TRUE@	$(am__DEPENDENCIES_1)
 AM_V_P = $(am__v_P_@AM_V@)
@@ -382,8 +380,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_UD_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_UD_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_UD_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_UD_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -393,9 +389,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_UD_TRUE@ud_SOURCES = 
 @ENABLED_BENCHMARK_UD_TRUE@libud_la_SOURCES = libud.c
 @ENABLED_BENCHMARK_UD_TRUE@ud_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_UD_TRUE@                     $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_UD_TRUE@                     libud.la \
 @ENABLED_BENCHMARK_UD_TRUE@                     $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_UD_TRUE@                     libud.la \
 @ENABLED_BENCHMARK_UD_TRUE@                     $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT)
 
 all: all-am

--- a/src/whetstone/Makefile.am
+++ b/src/whetstone/Makefile.am
@@ -32,9 +32,8 @@ whetstone_SOURCES       =
 libwhetstone_la_SOURCES = libwhetstone.c
 
 whetstone_LDADD         = $(DUMMY_CRT0) \
-                          $(top_builddir)/support/libmain.la \
-                          libwhetstone.la \
                           $(top_builddir)/support/libsupport.la \
+                          libwhetstone.la \
                           $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT) \
                           $(LIBM)
 

--- a/src/whetstone/Makefile.in
+++ b/src/whetstone/Makefile.in
@@ -170,9 +170,8 @@ whetstone_OBJECTS = $(am_whetstone_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_WHETSTONE_TRUE@whetstone_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_WHETSTONE_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_WHETSTONE_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_WHETSTONE_TRUE@	libwhetstone.la \
 @ENABLED_BENCHMARK_WHETSTONE_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_WHETSTONE_TRUE@	libwhetstone.la \
 @ENABLED_BENCHMARK_WHETSTONE_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_WHETSTONE_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_WHETSTONE_TRUE@	$(am__DEPENDENCIES_1) \
@@ -386,8 +385,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_WHETSTONE_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_WHETSTONE_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_WHETSTONE_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_WHETSTONE_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -397,9 +394,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_WHETSTONE_TRUE@whetstone_SOURCES = 
 @ENABLED_BENCHMARK_WHETSTONE_TRUE@libwhetstone_la_SOURCES = libwhetstone.c
 @ENABLED_BENCHMARK_WHETSTONE_TRUE@whetstone_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_WHETSTONE_TRUE@                          $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_WHETSTONE_TRUE@                          libwhetstone.la \
 @ENABLED_BENCHMARK_WHETSTONE_TRUE@                          $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_WHETSTONE_TRUE@                          libwhetstone.la \
 @ENABLED_BENCHMARK_WHETSTONE_TRUE@                          $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT) \
 @ENABLED_BENCHMARK_WHETSTONE_TRUE@                          $(LIBM)
 

--- a/src/wikisort/Makefile.am
+++ b/src/wikisort/Makefile.am
@@ -32,9 +32,8 @@ wikisort_SOURCES       =
 libwikisort_la_SOURCES = libwikisort.c
 
 wikisort_LDADD         = $(DUMMY_CRT0) \
-                         $(top_builddir)/support/libmain.la \
-                         libwikisort.la \
                          $(top_builddir)/support/libsupport.la \
+                         libwikisort.la \
                          $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT) \
                          $(LIBM)
 

--- a/src/wikisort/Makefile.in
+++ b/src/wikisort/Makefile.in
@@ -170,9 +170,8 @@ wikisort_OBJECTS = $(am_wikisort_OBJECTS)
 am__DEPENDENCIES_1 =
 @ENABLED_BENCHMARK_WIKISORT_TRUE@wikisort_DEPENDENCIES =  \
 @ENABLED_BENCHMARK_WIKISORT_TRUE@	$(am__DEPENDENCIES_1) \
-@ENABLED_BENCHMARK_WIKISORT_TRUE@	$(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_WIKISORT_TRUE@	libwikisort.la \
 @ENABLED_BENCHMARK_WIKISORT_TRUE@	$(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_WIKISORT_TRUE@	libwikisort.la \
 @ENABLED_BENCHMARK_WIKISORT_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_WIKISORT_TRUE@	$(am__DEPENDENCIES_1) \
 @ENABLED_BENCHMARK_WIKISORT_TRUE@	$(am__DEPENDENCIES_1) $(LIBM)
@@ -384,8 +383,6 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_WIKISORT_TRUE@              -I $(top_srcdir)/config/@ARCH@/chips/@CHIP@ \
 @ENABLED_BENCHMARK_WIKISORT_TRUE@              @CPPFLAGS@
 
-@ENABLED_BENCHMARK_WIKISORT_TRUE@AM_CFLAGS = @CFLAGS@
-@ENABLED_BENCHMARK_WIKISORT_TRUE@AM_LDFLAGS = @LDFLAGS@
 
 # Setup a $(LIBM) variable that we can use instead of either
 # $(DUMMY_LIBM) or -lm.  This way we don't risk pulling in
@@ -395,9 +392,8 @@ top_srcdir = @top_srcdir@
 @ENABLED_BENCHMARK_WIKISORT_TRUE@wikisort_SOURCES = 
 @ENABLED_BENCHMARK_WIKISORT_TRUE@libwikisort_la_SOURCES = libwikisort.c
 @ENABLED_BENCHMARK_WIKISORT_TRUE@wikisort_LDADD = $(DUMMY_CRT0) \
-@ENABLED_BENCHMARK_WIKISORT_TRUE@                         $(top_builddir)/support/libmain.la \
-@ENABLED_BENCHMARK_WIKISORT_TRUE@                         libwikisort.la \
 @ENABLED_BENCHMARK_WIKISORT_TRUE@                         $(top_builddir)/support/libsupport.la \
+@ENABLED_BENCHMARK_WIKISORT_TRUE@                         libwikisort.la \
 @ENABLED_BENCHMARK_WIKISORT_TRUE@                         $(DUMMY_LIBC) $(DUMMY_LIBGCC) $(DUMMY_COMPILERRT) \
 @ENABLED_BENCHMARK_WIKISORT_TRUE@                         $(LIBM)
 

--- a/support/Makefile.am
+++ b/support/Makefile.am
@@ -22,7 +22,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 noinst_LTLIBRARIES = libdummycrt0.la \
-                     libmain.la      \
                      libsupport.la   \
                      libdummygcc.la  \
                      libdummyc.la    \
@@ -33,8 +32,8 @@ if ARC
 endif
 
 libdummycrt0_la_SOURCES = dummy-crt0.c
-libmain_la_SOURCES      = main.c
-libsupport_la_SOURCES   = board.c   \
+libsupport_la_SOURCES   = main.c    \
+                          board.c   \
                           support.h
 libdummygcc_la_SOURCES  = dummy-libgcc.c $(MAYBE_ARC_MILLICODE)
 libdummyc_la_SOURCES    = dummy-libc.c
@@ -44,7 +43,5 @@ if CHIPSUPPORT_C
 libsupport_la_SOURCES += chip.c
 endif
 
-libmain_la_CPPFLAGS    = -I$(top_srcdir)/config/@ARCH@/boards/@BOARD@ \
-                         -I$(top_srcdir)/config/@ARCH@/chips/@CHIP@
 libsupport_la_CPPFLAGS = -I$(top_srcdir)/config/@ARCH@/boards/@BOARD@ \
                          -I$(top_srcdir)/config/@ARCH@/chips/@CHIP@

--- a/support/Makefile.in
+++ b/support/Makefile.in
@@ -145,13 +145,11 @@ libdummygcc_la_OBJECTS = $(am_libdummygcc_la_OBJECTS)
 libdummym_la_LIBADD =
 am_libdummym_la_OBJECTS = dummy-libm.lo
 libdummym_la_OBJECTS = $(am_libdummym_la_OBJECTS)
-libmain_la_LIBADD =
-am_libmain_la_OBJECTS = libmain_la-main.lo
-libmain_la_OBJECTS = $(am_libmain_la_OBJECTS)
 libsupport_la_LIBADD =
-am__libsupport_la_SOURCES_DIST = board.c support.h chip.c
+am__libsupport_la_SOURCES_DIST = main.c board.c support.h chip.c
 @CHIPSUPPORT_C_TRUE@am__objects_2 = libsupport_la-chip.lo
-am_libsupport_la_OBJECTS = libsupport_la-board.lo $(am__objects_2)
+am_libsupport_la_OBJECTS = libsupport_la-main.lo \
+	libsupport_la-board.lo $(am__objects_2)
 libsupport_la_OBJECTS = $(am_libsupport_la_OBJECTS)
 AM_V_P = $(am__v_P_@AM_V@)
 am__v_P_ = $(am__v_P_@AM_DEFAULT_V@)
@@ -199,10 +197,10 @@ am__v_CCLD_0 = @echo "  CCLD    " $@;
 am__v_CCLD_1 = 
 SOURCES = $(libdummyc_la_SOURCES) $(libdummycrt0_la_SOURCES) \
 	$(libdummygcc_la_SOURCES) $(libdummym_la_SOURCES) \
-	$(libmain_la_SOURCES) $(libsupport_la_SOURCES)
+	$(libsupport_la_SOURCES)
 DIST_SOURCES = $(libdummyc_la_SOURCES) $(libdummycrt0_la_SOURCES) \
 	$(am__libdummygcc_la_SOURCES_DIST) $(libdummym_la_SOURCES) \
-	$(libmain_la_SOURCES) $(am__libsupport_la_SOURCES_DIST)
+	$(am__libsupport_la_SOURCES_DIST)
 am__can_run_installinfo = \
   case $$AM_UPDATE_INFO_DIR in \
     n|no|NO) false;; \
@@ -364,7 +362,6 @@ top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 noinst_LTLIBRARIES = libdummycrt0.la \
-                     libmain.la      \
                      libsupport.la   \
                      libdummygcc.la  \
                      libdummyc.la    \
@@ -372,14 +369,10 @@ noinst_LTLIBRARIES = libdummycrt0.la \
 
 @ARC_TRUE@MAYBE_ARC_MILLICODE = arc-millicode.S
 libdummycrt0_la_SOURCES = dummy-crt0.c
-libmain_la_SOURCES = main.c
-libsupport_la_SOURCES = board.c support.h $(am__append_1)
+libsupport_la_SOURCES = main.c board.c support.h $(am__append_1)
 libdummygcc_la_SOURCES = dummy-libgcc.c $(MAYBE_ARC_MILLICODE)
 libdummyc_la_SOURCES = dummy-libc.c
 libdummym_la_SOURCES = dummy-libm.c
-libmain_la_CPPFLAGS = -I$(top_srcdir)/config/@ARCH@/boards/@BOARD@ \
-                         -I$(top_srcdir)/config/@ARCH@/chips/@CHIP@
-
 libsupport_la_CPPFLAGS = -I$(top_srcdir)/config/@ARCH@/boards/@BOARD@ \
                          -I$(top_srcdir)/config/@ARCH@/chips/@CHIP@
 
@@ -440,9 +433,6 @@ libdummygcc.la: $(libdummygcc_la_OBJECTS) $(libdummygcc_la_DEPENDENCIES) $(EXTRA
 libdummym.la: $(libdummym_la_OBJECTS) $(libdummym_la_DEPENDENCIES) $(EXTRA_libdummym_la_DEPENDENCIES) 
 	$(AM_V_CCLD)$(LINK)  $(libdummym_la_OBJECTS) $(libdummym_la_LIBADD) $(LIBS)
 
-libmain.la: $(libmain_la_OBJECTS) $(libmain_la_DEPENDENCIES) $(EXTRA_libmain_la_DEPENDENCIES) 
-	$(AM_V_CCLD)$(LINK)  $(libmain_la_OBJECTS) $(libmain_la_LIBADD) $(LIBS)
-
 libsupport.la: $(libsupport_la_OBJECTS) $(libsupport_la_DEPENDENCIES) $(EXTRA_libsupport_la_DEPENDENCIES) 
 	$(AM_V_CCLD)$(LINK)  $(libsupport_la_OBJECTS) $(libsupport_la_LIBADD) $(LIBS)
 
@@ -457,9 +447,9 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/dummy-libc.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/dummy-libgcc.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/dummy-libm.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libmain_la-main.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libsupport_la-board.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libsupport_la-chip.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libsupport_la-main.Plo@am__quote@
 
 .S.o:
 @am__fastdepCCAS_TRUE@	$(AM_V_CPPAS)$(CPPASCOMPILE) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $<
@@ -503,12 +493,12 @@ distclean-compile:
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LTCOMPILE) -c -o $@ $<
 
-libmain_la-main.lo: main.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmain_la_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -MT libmain_la-main.lo -MD -MP -MF $(DEPDIR)/libmain_la-main.Tpo -c -o libmain_la-main.lo `test -f 'main.c' || echo '$(srcdir)/'`main.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/libmain_la-main.Tpo $(DEPDIR)/libmain_la-main.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='main.c' object='libmain_la-main.lo' libtool=yes @AMDEPBACKSLASH@
+libsupport_la-main.lo: main.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libsupport_la_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -MT libsupport_la-main.lo -MD -MP -MF $(DEPDIR)/libsupport_la-main.Tpo -c -o libsupport_la-main.lo `test -f 'main.c' || echo '$(srcdir)/'`main.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/libsupport_la-main.Tpo $(DEPDIR)/libsupport_la-main.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='main.c' object='libsupport_la-main.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmain_la_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -c -o libmain_la-main.lo `test -f 'main.c' || echo '$(srcdir)/'`main.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libsupport_la_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -c -o libsupport_la-main.lo `test -f 'main.c' || echo '$(srcdir)/'`main.c
 
 libsupport_la-board.lo: board.c
 @am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libsupport_la_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -MT libsupport_la-board.lo -MD -MP -MF $(DEPDIR)/libsupport_la-board.Tpo -c -o libsupport_la-board.lo `test -f 'board.c' || echo '$(srcdir)/'`board.c

--- a/support/chip.c
+++ b/support/chip.c
@@ -23,6 +23,7 @@
 
 /* This is just a wrapper for the chip specific support file if there is one. */
 
+#include "config.h"
 
 #ifdef HAVE_CHIPSUPPORT_H
 #include "chipsupport.c"

--- a/testsuite/ChangeLog
+++ b/testsuite/ChangeLog
@@ -1,3 +1,7 @@
+2019-03-25  Graham Markall  <graham.markall@embecosm.com>
+
+	* config/ty_eysgjn.exp: New file.
+
 2019-03-15  Graham Markall  <graham.markall@embecosm.com>
 
 	* config/generic.exp (generic_filter_benchmark, generic_init): New

--- a/testsuite/config/ty_eysgjn.exp
+++ b/testsuite/config/ty_eysgjn.exp
@@ -1,0 +1,34 @@
+# Copyright (C) 2018 Embecosm Limited.
+
+# Contributor Graham Markall <graham.markall@embecosm.com>
+
+# This file is part of BEEBS
+
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation; either version 3 of the License, or (at your option)
+# any later version.
+
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set_board_info beebs,benchmarks "$env(BENCHMARKS)"
+
+proc ty_eysgjn_filter_benchmark { b f } {
+  return 0
+}
+
+proc ty_eysgjn_init { test_file_name } {
+  uplevel #0 {
+    proc beebs_filter_benchmark { b f } {
+      return [ty_eysgjn_filter_benchmark $b $f]
+    }
+  }
+}


### PR DESCRIPTION
To fix #59 (Configure script ignores CFLAGS etc. from board / chip
configuration) we add the board flags to flags before doing any config
checks.

To fix #60 (Including chipsupport.c in chip.c doesn't work), we include
config.h in chip.h, so that it has the appropriate setting of
HAVE_BOARDSUPPORT_H. This allows it to include chipsupport.c correctly
as necessary.

This then exposes a new issue - any board whose chipsupport.c contains
startup code (instead of using startup files provided by libc) cannot
link because main cannot be resolved due to the link order. Rather than
doing something complicated with groups when linking or attempting to
change link order to resolve this, we instead merge libmain and
libsupport into a single libsupport library.

The next issue that requires attention is that the configuration for the
Taiyo Yuden EYSGJN results in empty executables, as there appears to be
nothing explicitly linked in (no startup code is included for this
board). We resolve this by setting the vector table as the ELF entry
point, to force it and all the relocations in it to be included. The
board / loader doesn't use the ELF entry point, so this shouldn't result
in incorrect execution.

We also add a DejaGNU board file for the Taiyo Yuden EYSGJN board, so
that the size of executables built for the board can easily be assessed
with `make check`.