### PR TITLE
More flexibility when testing.

### DIFF
--- a/testsuite/ChangeLog
+++ b/testsuite/ChangeLog
@@ -1,3 +1,21 @@
+2019-04-10  Jeremy Bennett  <jeremy.bennett@embecosm.com>
+
+	This gives greater flexibility when testing with BEEBS.  The
+	timeout to be used for execution tests can be set through the
+	BEEBS_TIMEOUT variable, for example:
+
+	BEEBS_TIMEOUT=300 make check
+
+	The tests to be executed can be specified on the command line
+	using the RUNTESTFLAGS option, for example:
+
+	make check RUNTESTFLAGS="execute.exp=sglib-mergesort,sglib-listsort"
+
+	* beebs.test/execute.exp: Pick up BEEBS_TIMEOUT environment
+	variable if set.
+	* lib/beebs.exp: Allow set of benchmarks to run to be specified
+	via RUNTESTFLAGS.
+
 2019-03-25  Graham Markall  <graham.markall@embecosm.com>
 
 	* config/ty_eysgjn.exp: New file.

--- a/testsuite/beebs.test/execute.exp
+++ b/testsuite/beebs.test/execute.exp
@@ -19,6 +19,13 @@
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+# Set timeout based on optional environment variable.
+
+if { [llength [array names env BEEBS_TIMEOUT]] > 0 } {
+    set timeout $env(BEEBS_TIMEOUT)
+    verbose "BEEBS_TIMEOUT set to $timeout"
+}
+
 foreach target $target_list {
     beebs_run_all_benchmarks $target ${objdir}/../src
 }

--- a/testsuite/lib/beebs.exp
+++ b/testsuite/lib/beebs.exp
@@ -65,6 +65,7 @@ proc beebs_run_benchmark { benchmark filename } {
 
 # Main loop to run all benchmarks.
 proc beebs_run_all_benchmarks { board objdir } {
+    global runtests
     global beebs_run_benchmark_result
 
     # Perform any setup required before running any benchmarks.
@@ -82,6 +83,17 @@ proc beebs_run_all_benchmarks { board objdir } {
     # variable contains all the directories that can contain
     # benchmarks, the benchmarks themselves are the executable files
     # within those directories.
+
+    # This can be overridden from the command line (for example by "make check
+    # RUNTESTFLAGS=execute.exp=mergesort"), in which case the args to
+    # RUNTESTFLAGS will appear in the gloval variable "runtests", with the
+    # first argument being the ".exp" file, which we must discard.
+
+    set tests_to_run [lindex $runtests 1]
+    if { [llength $tests_to_run] > 0 } {
+	set benchmarks [split $tests_to_run ","]
+    }
+
     foreach benchmark $benchmarks {
 
         # Now find all the executable files to run.


### PR DESCRIPTION
	This gives greater flexibility when testing with BEEBS.  The
	timeout to be used for execution tests can be set through the
	BEEBS_TIMEOUT variable, for example:

	BEEBS_TIMEOUT=300 make check

	The tests to be executed can be specified on the command line
	using the RUNTESTFLAGS option, for example:

	make check RUNTESTFLAGS="execute.exp=sglib-mergesort,sglib-listsort"

testsuite/ChangeLog:

	* beebs.test/execute.exp: Pick up BEEBS_TIMEOUT environment
	variable if set.
	* lib/beebs.exp: Allow set of benchmarks to run to be specified
	via RUNTESTFLAGS.