### PR TITLE
Wip issue 40

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,15 @@
 
 	This replaces all calls to rand () by rand_beebs, a standard
 	source implementation, independent of RAND_MAX and choice of
+	multiplier and offset.
+
+	* src/rijndael/aesxam.c (rand_beebs): Created.
+	(fillrand, encfile, decfile): Use rand_beebs () instead of rand ().
+
+2019-04-18  Jeremy Bennett  <jeremy.bennett@embecosm.com>
+
+	This replaces all calls to rand () by rand_beebs, a standard
+	source implementation, independent of RAND_MAX and choice of
 	multiplier and offset. It also uses alloca instead of malloc/free
 	to reduce library dependency.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,17 @@
+2019-04-18  Jeremy Bennett  <jeremy.bennett@embecosm.com>
+
+	This replaces all calls to rand () by rand_beebs, a standard
+	source implementation, independent of RAND_MAX and choice of
+	multiplier and offset. It also uses alloca instead of malloc/free
+	to reduce library dependency.
+
+	* src/mergesort/libmergesort.c: Comment out Var andd Allocate macros.
+	(rand_beebs): Created.
+	(MergeSort): Replace macros by alloca and comment out call to free.
+	(TestingRandom, TestingMostlyDescending, TestingMostlyAscending)
+	(TestingJittered, TestingMostlyEqual): Replace rand by rand_beebs.
+	(benchmark): Comment out use of srand.
+
 2019-04-04  Jeremy Bennett  <jeremy.bennett@embecosm.com>
 
 	This replaces all calls to rand () by rand_beebs, a standard
@@ -5,8 +19,8 @@
 	multiplier and offset.
 
 	* src/crc32/crc_32.c (rand_beebs): Created.
-	(DWORD crc32pseudo): Use rand_beebs () instead of rand ().
-	(int verify_benchmark): Set value to be consistent with use of
+	(crc32pseudo): Use rand_beebs () instead of rand ().
+	(verify_benchmark): Set value to be consistent with use of
 	rand_beebs.
 
 2019-03-18  Graham Markall  <graham.markall@embecosm.com>

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,19 @@
 
 	This replaces all calls to rand () by rand_beebs, a standard
 	source implementation, independent of RAND_MAX and choice of
+	multiplier and offset. It also eliminates an unused macro.
+
+	* src/wikisort/libwikisort.c: Comment out Allocate macro, which is
+	never used.
+	(rand_beebs): Created.
+	(TestingRandom, TestingMostlyDescending, TestingMostlyAscending)
+	(TestingJittered, TestingMostlyEqual): Replace rand by rand_beebs.
+	(benchmark): Comment out use of srand.
+
+2019-04-18  Jeremy Bennett  <jeremy.bennett@embecosm.com>
+
+	This replaces all calls to rand () by rand_beebs, a standard
+	source implementation, independent of RAND_MAX and choice of
 	multiplier and offset.
 
 	* src/rijndael/aesxam.c (rand_beebs): Created.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,15 @@
 2019-04-18  Jeremy Bennett  <jeremy.bennett@embecosm.com>
 
+	The mask used in rand_beebs needs to be long unsigned, to ensure
+	correct behavior where int is 16-bits long.
+
+	* src/crc32/crc_32.c (rand_beebs): Make mask constant long unsigned.
+	* src/mergesort/libmergesort.c (rand_beebs): Likewise.
+	* src/rijndael/aesxam.c (rand_beebs): Likewise.
+	* src/wikisort/libwikisort.c (rand_beebs): Likewise.
+
+2019-04-18  Jeremy Bennett  <jeremy.bennett@embecosm.com>
+
 	BEEBS uses its own random number generator which works on all
 	architectures, even where int is 16 bits long. To go with this, it
 	provides its own definition of the constant RAND_MAX as 2^15-1,

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,15 @@
 2019-04-18  Jeremy Bennett  <jeremy.bennett@embecosm.com>
 
+	BEEBS uses its own random number generator which works on all
+	architectures, even where int is 16 bits long. To go with this, it
+	provides its own definition of the constant RAND_MAX as 2^15-1,
+	its smallest permitted value.
+
+	* src/mergesort/libmergesort.c: Provide custom definition of RAND_MAX.
+	* src/wikisort/libwikisort.c: Likewise.
+
+2019-04-18  Jeremy Bennett  <jeremy.bennett@embecosm.com>
+
 	This replaces all calls to rand () by rand_beebs, a standard
 	source implementation, independent of RAND_MAX and choice of
 	multiplier and offset. It also eliminates an unused macro.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,14 @@
+2019-04-04  Jeremy Bennett  <jeremy.bennett@embecosm.com>
+
+	This replaces all calls to rand () by rand_beebs, a standard
+	source implementation, independent of RAND_MAX and choice of
+	multiplier and offset.
+
+	* src/crc32/crc_32.c (rand_beebs): Created.
+	(DWORD crc32pseudo): Use rand_beebs () instead of rand ().
+	(int verify_benchmark): Set value to be consistent with use of
+	rand_beebs.
+
 2019-03-18  Graham Markall  <graham.markall@embecosm.com>
 
 	* configure: Regenerate.

--- a/src/crc32/crc_32.c
+++ b/src/crc32/crc_32.c
@@ -163,7 +163,7 @@ rand_beebs ()
 {
   static long int seed = 0;
 
-  seed = (seed * 1103515245L + 12345) & ((1U << 31) - 1);
+  seed = (seed * 1103515245L + 12345) & ((1UL << 31) - 1);
   return (int) (seed >> 16);
 
 }

--- a/src/mergesort/libmergesort.c
+++ b/src/mergesort/libmergesort.c
@@ -50,6 +50,12 @@
 
 */
 
+/* BEEBS fixes RAND_MAX to its lowest permitted value, 2^15-1 */
+
+#ifdef RAND_MAX
+#undef RAND_MAX
+#endif
+#define RAND_MAX ((1U << 15) - 1)
 
 /* Yield a sequence of random numbers in the range [0, 2^15-1].
 

--- a/src/mergesort/libmergesort.c
+++ b/src/mergesort/libmergesort.c
@@ -70,7 +70,7 @@ rand_beebs ()
 {
   static long int seed = 0;
 
-  seed = (seed * 1103515245L + 12345) & ((1U << 31) - 1);
+  seed = (seed * 1103515245L + 12345) & ((1UL << 31) - 1);
   return (int) (seed >> 16);
 
 }

--- a/src/rijndael/aesxam.c
+++ b/src/rijndael/aesxam.c
@@ -91,7 +91,7 @@ rand_beebs ()
 {
   static long int seed = 0;
 
-  seed = (seed * 1103515245L + 12345) & ((1U << 31) - 1);
+  seed = (seed * 1103515245L + 12345) & ((1UL << 31) - 1);
   return (int) (seed >> 16);
 
 }

--- a/src/rijndael/aesxam.c
+++ b/src/rijndael/aesxam.c
@@ -1,5 +1,3 @@
-
-
 /* BEEBS rijndael benchmark
 
    Copyright (C) 2014 Embecosm Limited and University of Bristol
@@ -58,6 +56,9 @@
 /*                                                              */
 /* which should return a file 'file2.c' identical to 'file.c'   */
 
+/* The BEEBS version of this code uses its own version of rand, to
+   avoid library/architecture variation. */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <ctype.h>
@@ -76,6 +77,25 @@
 #define FLEN flen
 
 #define RAND(a,b) (((a = 36969 * (a & 65535) + (a >> 16)) << 16) + (b = 18000 * (b & 65535) + (b >> 16))  )
+
+/* Yield a sequence of random numbers in the range [0, 2^15-1].
+
+   The seed is always initialized to zero.  long int is guaranteed to be at
+   least 32 bits. The seed only ever uses 31 bits (so is positive).
+
+   For BEEBS this gets round different operating systems using different
+   multipliers and offsets and RAND_MAX variations. */
+
+static int
+rand_beebs ()
+{
+  static long int seed = 0;
+
+  seed = (seed * 1103515245L + 12345) & ((1U << 31) - 1);
+  return (int) (seed >> 16);
+
+}
+
 
 void fillrand(byte *buf, int len)
 {
@@ -117,7 +137,7 @@ int encfile(aes *ctx, byte *outbuf)
    for(j = 0; j <256; j++)
    {                               /* input 1st 16 bytes to buf[1..16] */
       for(k = 0; k < 16; ++k)
-         inbuf[k] = rand();
+         inbuf[k] = rand_beebs();
 
       for(i = 0; i < 16; ++i)         /* xor in previous cipher text  */
          inbuf[i] ^= outbuf[i];
@@ -137,7 +157,7 @@ int decfile(aes *ctx, byte *outbuf)
    fillrand(inbuf1, 16);           /* set an IV for CBC mode           */
 
    for(k = 0; k < 16; ++k)
-      inbuf2[k] = rand();
+      inbuf2[k] = rand_beebs();
 
    decrypt(inbuf2, outbuf, ctx);   /* decrypt it                       */
 
@@ -150,7 +170,7 @@ int decfile(aes *ctx, byte *outbuf)
    for(j = 0; j < 256; ++j)
    {
       for(k = 0; k < 16; ++k)
-         bp1[k] = rand();
+         bp1[k] = rand_beebs();
 
       decrypt(bp1, outbuf, ctx);  /* decrypt the new input block and  */
 

--- a/src/wikisort/libwikisort.c
+++ b/src/wikisort/libwikisort.c
@@ -48,6 +48,13 @@
 #define Allocate(type, count)				(type *)malloc((count) * sizeof(type))
 */
 
+/* BEEBS fixes RAND_MAX to its lowest permitted value, 2^15-1 */
+
+#ifdef RAND_MAX
+#undef RAND_MAX
+#endif
+#define RAND_MAX ((1U << 15) - 1)
+
 /* Yield a sequence of random numbers in the range [0, 2^15-1].
 
    The seed is always initialized to zero.  long int is guaranteed to be at

--- a/src/wikisort/libwikisort.c
+++ b/src/wikisort/libwikisort.c
@@ -1,5 +1,3 @@
-
-
 /* BEEBS wikisort benchmark
 
    Originally from https://github.com/BonzaiThePenguin/WikiSort
@@ -46,7 +44,28 @@
 #endif
 
 #define Var(name, value)				__typeof__(value) name = value
+/* Copied from libmergesort, but Allocate never used here, so commented out for clarity.
 #define Allocate(type, count)				(type *)malloc((count) * sizeof(type))
+*/
+
+/* Yield a sequence of random numbers in the range [0, 2^15-1].
+
+   The seed is always initialized to zero.  long int is guaranteed to be at
+   least 32 bits. The seed only ever uses 31 bits (so is positive).
+
+   For BEEBS this gets round different operating systems using different
+   multipliers and offsets and RAND_MAX variations. */
+
+static int
+rand_beebs ()
+{
+  static long int seed = 0;
+
+  seed = (seed * 1103515245L + 12345) & ((1U << 31) - 1);
+  return (int) (seed >> 16);
+
+}
+
 
 long Min(const long a, const long b) {
 	if (a < b) return a;
@@ -653,15 +672,15 @@ long TestingPathological(long index, long total) {
 }
 
 long TestingRandom(long index, long total) {
-	return rand();
+	return rand_beebs();
 }
 
 long TestingMostlyDescending(long index, long total) {
-	return total - index + rand() * 1.0/RAND_MAX * 5 - 2.5;
+	return total - index + rand_beebs() * 1.0/RAND_MAX * 5 - 2.5;
 }
 
 long TestingMostlyAscending(long index, long total) {
-	return index + rand() * 1.0/RAND_MAX * 5 - 2.5;
+	return index + rand_beebs() * 1.0/RAND_MAX * 5 - 2.5;
 }
 
 long TestingAscending(long index, long total) {
@@ -677,11 +696,11 @@ long TestingEqual(long index, long total) {
 }
 
 long TestingJittered(long index, long total) {
-	return (rand() * 1.0/RAND_MAX <= 0.9) ? index : (index - 2);
+	return (rand_beebs() * 1.0/RAND_MAX <= 0.9) ? index : (index - 2);
 }
 
 long TestingMostlyEqual(long index, long total) {
-	return 1000 + rand() * 1.0/RAND_MAX * 4;
+	return 1000 + rand_beebs() * 1.0/RAND_MAX * 4;
 }
 
 
@@ -722,7 +741,10 @@ int benchmark() {
 	};
 
 	/* initialize the random-number generator */
+	/* The original code used srand here, but not needed since we are
+	   using a fixed random number generator for reproducibility.
 	srand(0);
+	*/
 	/*srand(10141985);*/ /* in case you want the same random numbers */
 
 

--- a/src/wikisort/libwikisort.c
+++ b/src/wikisort/libwikisort.c
@@ -68,7 +68,7 @@ rand_beebs ()
 {
   static long int seed = 0;
 
-  seed = (seed * 1103515245L + 12345) & ((1U << 31) - 1);
+  seed = (seed * 1103515245L + 12345) & ((1UL << 31) - 1);
   return (int) (seed >> 16);
 
 }


### PR DESCRIPTION
This set of commits fixes issue 40 by using a custom version of `rand()` which is consistent across all architectures and where necessary defining `RAND_MAX` to be 2<sup>15</sup>-1, its lowest permitted value and compatible where `int` is 16-bits long.
