### PR TITLE
Fix use of malloc/free in the ctl programs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,28 @@
 2019-04-18  Jeremy Bennett  <jeremy.bennett@embecosm.com>
 
+	The use of malloc/free in embedded applications is
+	problematic. For a benchmark it also places heavy dependence on a
+	library impementation.  This commit replaces library malloc/free by
+	simple in program allocation from a block of global memory.
+
+	* src/ctl-string/string.c (init_heap, malloc_beebs, free_beebs):
+	Created.
+	(ctl_StringInitSize, ctl_StringInitCopy): Replace malloc by
+	malloc_beebs.
+	(ctl_StringFree): Replace free by malloc_free.
+	(ctl_StringSet, ctl_StringSetString, ctl_StringAppend)
+	(ctl_StringInsertAt, ctl_StringSetSubStr): Replace malloc by
+	malloc_beebs.
+	(initialise_benchmark): Add call to init_heap.
+	* src/ctl/ctl.c (init_heap, malloc_beebs, free_beebs):
+	Created.
+	(initialise_benchmark): Add call to init_heap.
+	* src/ctl/stack.h: Replace calls to malloc by calls to
+	malloc_beebs and calls to free by calls to malloc_free throughout.
+	* src/ctl/vector.h: Likewise.
+
+2019-04-18  Jeremy Bennett  <jeremy.bennett@embecosm.com>
+
 	The mask used in rand_beebs needs to be long unsigned, to ensure
 	correct behavior where int is 16-bits long.
 

--- a/src/ctl/ctl.c
+++ b/src/ctl/ctl.c
@@ -30,6 +30,54 @@ typedef struct {
   int a, b;
 } pair;
 
+/* BEEBS heap is just an array */
+
+#include <stddef.h>
+
+#define HEAP_SIZE 8192
+static char heap[HEAP_SIZE];
+static void *heap_ptr;
+static void *heap_end;
+
+/* Initialize the BEEBS heap pointers */
+
+static void
+init_heap ()
+{
+    heap_ptr = (void *) heap;
+    heap_end = heap_ptr + HEAP_SIZE;
+}
+
+/* BEEBS version of malloc.
+
+   This is primarily to reduce library and OS dependencies. Malloc is
+   generally not used in embedded code, or if it is, only in well defined
+   contexts to pre-allocate a fixed amount of memory. So this simplistic
+   implementation is just fine. */
+
+static void *
+malloc_beebs (size_t size)
+{
+    void *new_ptr = heap_ptr;
+
+    if (((heap_ptr + size) > heap_end) || (0 == size))
+	return NULL;
+    else
+	{
+	    heap_ptr += size;
+	    return new_ptr;
+	}
+}
+
+/* BEEBS version of free.
+
+   For our simplified version of memory handling, free can just do nothing. */
+
+static void
+free_beebs (void *ptr)
+{
+}
+
 #ifdef CTL_VECTOR
 #include "vector.h"
 
@@ -135,6 +183,7 @@ void initialise_benchmark() {
   begin = 4;
   end = 50;
   end2 = 8;
+  init_heap ();
 }
 
 int verify_benchmark(int r)

--- a/src/ctl/stack.h
+++ b/src/ctl/stack.h
@@ -37,13 +37,13 @@ typedef struct CTL_##type##STACK ctl_##type##Stack;	\
 													\
 ctl_##type##Stack* ctl_##type##StackInitSize(int BlockSize)\
 {													\
-	ctl_##type##Stack* s=malloc(sizeof(ctl_##type##Stack));\
+	ctl_##type##Stack* s=malloc_beebs(sizeof(ctl_##type##Stack));\
 	if(!s)											\
 	{												\
 		return NULL;								\
 	}												\
 	s->alloc		= BlockSize;					\
-	s->value		= malloc(BlockSize*sizeof(type));\
+	s->value		= malloc_beebs(BlockSize*sizeof(type));\
 	if(!s->value)									\
 	{												\
 		return NULL;								\
@@ -60,13 +60,13 @@ ctl_##type##Stack* ctl_##type##StackInit(void)		\
 													\
 ctl_##type##Stack* ctl_##type##StackInitCopy(ctl_##type##Stack* stack)\
 {													\
-	ctl_##type##Stack* s=malloc(sizeof(ctl_##type##Stack));\
+	ctl_##type##Stack* s=malloc_beebs(sizeof(ctl_##type##Stack));\
 	if(!s)											\
 	{												\
 		return NULL;								\
 	}												\
 	s->alloc		= stack->alloc;					\
-	s->value		= malloc(stack->alloc*sizeof(type));\
+	s->value		= malloc_beebs(stack->alloc*sizeof(type));\
 	if(!s->value)									\
 	{												\
 		return NULL;								\
@@ -78,8 +78,8 @@ ctl_##type##Stack* ctl_##type##StackInitCopy(ctl_##type##Stack* stack)\
 													\
 void ctl_##type##StackFree(ctl_##type##Stack* s)	\
 {													\
-	free(s->value);									\
-	free(s);										\
+	free_beebs(s->value);									\
+	free_beebs(s);										\
 }													\
 													\
 int ctl_##type##StackPush(ctl_##type##Stack* s, type value)\

--- a/src/ctl/vector.h
+++ b/src/ctl/vector.h
@@ -38,13 +38,13 @@ typedef struct CTL_##type##VECTOR ctl_##type##Vector;		\
 															\
 ctl_##type##Vector* ctl_##type##VectorInitSize(int BlockSize)\
 {															\
-	ctl_##type##Vector* s=malloc(sizeof(ctl_##type##Vector));\
+	ctl_##type##Vector* s=malloc_beebs(sizeof(ctl_##type##Vector));\
 	if(!s)													\
 	{														\
 		return NULL;										\
 	}														\
 	s->BlockSize	= BlockSize;							\
-	s->value		= malloc(s->BlockSize*sizeof(type));	\
+	s->value		= malloc_beebs(s->BlockSize*sizeof(type));	\
 	if(!s->value)											\
 	{														\
 		ctl_errno	= CTL_OUT_OF_MEMORY;					\
@@ -64,13 +64,13 @@ ctl_##type##Vector* ctl_##type##VectorInit(void)			\
 															\
 ctl_##type##Vector* ctl_##type##VectorInitCopy(ctl_##type##Vector* vector)\
 {															\
-	ctl_##type##Vector* s=malloc(sizeof(ctl_##type##Vector));\
+	ctl_##type##Vector* s=malloc_beebs(sizeof(ctl_##type##Vector));\
 	if(!s)													\
 	{														\
 		return NULL;										\
 	}														\
 	s->BlockSize	= vector->BlockSize;					\
-	s->value		= malloc(vector->alloc*sizeof(type));	\
+	s->value		= malloc_beebs(vector->alloc*sizeof(type));	\
 	if(!s->value)											\
 	{														\
 		ctl_errno	= CTL_OUT_OF_MEMORY;					\
@@ -86,8 +86,8 @@ ctl_##type##Vector* ctl_##type##VectorInitCopy(ctl_##type##Vector* vector)\
 															\
 void ctl_##type##VectorFree(ctl_##type##Vector* s)			\
 {															\
-	free(s->value);											\
-	free(s);												\
+	free_beebs(s->value);											\
+	free_beebs(s);												\
 }															\
 															\
 int ctl_##type##VectorPush_Back(ctl_##type##Vector* s, type push)\
@@ -96,7 +96,7 @@ int ctl_##type##VectorPush_Back(ctl_##type##Vector* s, type push)\
 	{														\
 		type* secure;										\
 		s->alloc+=s->BlockSize;								\
-		secure=malloc(s->alloc*sizeof(type));				\
+		secure=malloc_beebs(s->alloc*sizeof(type));				\
 		if(!secure)											\
 		{													\
 			ctl_errno	= CTL_OUT_OF_MEMORY;				\
@@ -134,7 +134,7 @@ int ctl_##type##VectorSet(ctl_##type##Vector* s, type* vector, size_t size)\
 	{														\
 		size_t alloc=(size/s->BlockSize+1)*s->BlockSize;	\
 		type* secure;										\
-		secure=malloc(alloc*sizeof(type));					\
+		secure=malloc_beebs(alloc*sizeof(type));					\
 		if(!secure)											\
 		{													\
 			ctl_errno	= CTL_OUT_OF_MEMORY;				\
@@ -157,7 +157,7 @@ int ctl_##type##VectorSetVector(ctl_##type##Vector* s, ctl_##type##Vector* vecto
 	{														\
 		size_t alloc=(vector->size/s->BlockSize+1)*s->BlockSize;\
 		type* secure;										\
-		secure=malloc(alloc*sizeof(type));					\
+		secure=malloc_beebs(alloc*sizeof(type));					\
 		if(!secure)											\
 		{													\
 			ctl_errno	= CTL_OUT_OF_MEMORY;				\
@@ -194,7 +194,7 @@ int ctl_##type##VectorInsert(ctl_##type##Vector* s, size_t pos, type value)\
 	{														\
 		type* secure;										\
 		s->alloc+=s->BlockSize;								\
-		secure=malloc(s->alloc*sizeof(type));				\
+		secure=malloc_beebs(s->alloc*sizeof(type));				\
 		if(!secure)											\
 		{													\
 			s->alloc-=s->BlockSize;							\
@@ -227,7 +227,7 @@ int ctl_##type##VectorDelete(ctl_##type##Vector* s, size_t begin, size_t end)\
 int ctl_##type##VectorShrink(ctl_##type##Vector* s)			\
 {															\
 	type* secure;											\
-	secure=malloc(s->size*sizeof(type));					\
+	secure=malloc_beebs(s->size*sizeof(type));					\
 	if(!secure)												\
 	{														\
 		ctl_errno=CTL_OUT_OF_MEMORY;						\


### PR DESCRIPTION
	The use of malloc/free in embedded applications is
	problematic. For a benchmark it also places heavy dependence on a
	library impementation.  This commit replaces library malloc/free by
	simple in program allocation from a block of global memory.

ChangeLog:

	* src/ctl-string/string.c (init_heap, malloc_beebs, free_beebs):
	Created.
	(ctl_StringInitSize, ctl_StringInitCopy): Replace malloc by
	malloc_beebs.
	(ctl_StringFree): Replace free by malloc_free.
	(ctl_StringSet, ctl_StringSetString, ctl_StringAppend)
	(ctl_StringInsertAt, ctl_StringSetSubStr): Replace malloc by
	malloc_beebs.
	(initialise_benchmark): Add call to init_heap.
	* src/ctl/ctl.c (init_heap, malloc_beebs, free_beebs):
	Created.
	(initialise_benchmark): Add call to init_heap.
	* src/ctl/stack.h: Replace calls to malloc by calls to
	malloc_beebs and calls to free by calls to malloc_free throughout.
	* src/ctl/vector.h: Likewise.