### PR TITLE
Jpb malloc fix wip

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,16 @@
 2019-04-18  Jeremy Bennett  <jeremy.bennett@embecosm.com>
 
+	Modify one more sglib benchmarks to use its own version of malloc
+	and free to reduce library and OS dependency.
+
+	* src/sglib-listsort/listsort.c (init_heap, malloc_beebs, free_beebs):
+	Created.
+	(initialise_benchmark): Add call to init_heap
+	(benchmark): Replace call to malloc by malloc_beebs and call to
+	free by free_beebs.
+
+2019-04-18  Jeremy Bennett  <jeremy.bennett@embecosm.com>
+
 	Modify both trio benchmarks to use there own version of malloc,
 	free and calloc to reduce library and OS dependency.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,16 @@
 2019-04-18  Jeremy Bennett  <jeremy.bennett@embecosm.com>
 
+	Modify the dtoa benchmark to use its own version of malloc and
+	free to reduce library and OS dependency.  For this benchmark,
+	hooks are provided to facilitate this.
+
+	* src/dtoa/libdtoa.c (MALLOC, FREE): Define these to be
+	malloc_beebs and free_beebs respectively.
+	(init_heap, malloc_beebs, free_beebs): Created.
+	(initialise_benchmark): Add call to init_heap.
+
+2019-04-18  Jeremy Bennett  <jeremy.bennett@embecosm.com>
+
 	Modify the dijkstra test to use its own version of malloc and
 	free to reduce library and OS dependency.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,19 @@
 2019-04-18  Jeremy Bennett  <jeremy.bennett@embecosm.com>
 
+	Modify the huffbench benchmark to use its own version of malloc
+	and free to reduce library and OS dependency.
+
+	* src/huffbench/libhuffbench.c (init_heap, malloc_beebs)
+	(free_beebs): Created.
+	(generate_test_data): Replace call to malloc by call to
+	malloc_beebs.
+	(compdecomp): Replace call to malloc by call to malloc_beebs and
+	free by call to malloc_free.
+	(benchmark): Replace call to free by call to malloc_free.
+	(initialise_benchmark): Add call to init_heap.
+
+2019-04-18  Jeremy Bennett  <jeremy.bennett@embecosm.com>
+
 	Modify the fasta benchmark to use alloca rather than malloc to
 	reduce library and OS dependency.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,17 @@
 2019-04-18  Jeremy Bennett  <jeremy.bennett@embecosm.com>
 
+	* src/qrduino/qrframe.c (init_heap, malloc_beebs, calloc_beebs)
+	(free_beebs): Created.
+	(initframe): Replace calloc and malloc by calloc_beebs and
+	malloc-beebs respectively.
+	(freeframe): Replace free by free_beebs.
+	(initecc): Replace malloc by malloc_beebs.
+	(freeecc): Replace free by free_beebs.
+	* src/qrduino/qrtest.c (initialise_benchmark): Add call to
+	init_heap.
+
+2019-04-18  Jeremy Bennett  <jeremy.bennett@embecosm.com>
+
 	Modify the miniz benchmark to use its own version of malloc, free
 	and realloc to reduce library and OS dependency.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,16 @@
 2019-04-18  Jeremy Bennett  <jeremy.bennett@embecosm.com>
 
+	Modify the dijkstra test to use its own version of malloc and
+	free to reduce library and OS dependency.
+
+	* src/dijkstra/dijkstra_small.c (qinit_heap, qmalloc_beebs)
+	(qfree_beebs): Created.
+	(void enqueue): Replace malloc by qmalloc_beebs.
+	(int dijkstra): Replace free by qfree_beebs.
+	(initialise_benchmark): Add call to qinit_heap.
+
+2019-04-18  Jeremy Bennett  <jeremy.bennett@embecosm.com>
+
 	The use of malloc/free in embedded applications is
 	problematic. For a benchmark it also places heavy dependence on a
 	library impementation.  This commit replaces library malloc/free by

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,34 @@
 2019-04-18  Jeremy Bennett  <jeremy.bennett@embecosm.com>
 
+	Modify all the sglib benchmarks to use there own version of malloc
+	and free to reduce library and OS dependency.
+
+	* src/sglib-dllist/dllist.c (init_heap, malloc_beebs, free_beebs):
+	Created.
+	(initialise_benchmark): Add call to init_heap
+	(benchmark): Replace call to malloc by malloc_beebs and call to
+	free by free_beebs.
+	* src/sglib-hashtable/hashtable.c (init_heap, malloc_beebs)
+	(free_beebs): Created.
+	(initialise_benchmark): Add call to init_heap
+	(benchmark): Replace call to malloc by malloc_beebs and call to
+	free by free_beebs.
+	* src/sglib-listinsertsort/listinsertsort.c (init_heap)
+	(malloc_beebs, free_beebs): Created.
+	(initialise_benchmark): Add call to init_heap
+	(benchmark): Replace call to malloc by malloc_beebs and call to
+	free by free_beebs.
+	* src/sglib-rbtree/rbtree.c (init_heap, malloc_beebs, free_beebs):
+	Created.
+	(initialise_benchmark): Add call to init_heap
+	(benchmark): Replace call to malloc by malloc_beebs and call to
+	free by free_beebs.
+
+2019-04-18  Jeremy Bennett  <jeremy.bennett@embecosm.com>
+
+	Modify the qrduino benchmark to use its own version of malloc, free
+	and calloc to reduce library and OS dependency.
+
 	* src/qrduino/qrframe.c (init_heap, malloc_beebs, calloc_beebs)
 	(free_beebs): Created.
 	(initframe): Replace calloc and malloc by calloc_beebs and

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,13 @@
 2019-04-18  Jeremy Bennett  <jeremy.bennett@embecosm.com>
 
+	In two places the declaration of init_heap followed K&R, rather
+	than ANSI syntax.  Now corrected.
+
+	* src/dtoa/libdtoa.c (init_heap): Correct prototype of the function.
+	* src/huffbench/libhuffbench.c (init_heap): Likewise.
+
+2019-04-18  Jeremy Bennett  <jeremy.bennett@embecosm.com>
+
 	Modify one more sglib benchmarks to use its own version of malloc
 	and free to reduce library and OS dependency.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,15 @@
 2019-04-18  Jeremy Bennett  <jeremy.bennett@embecosm.com>
 
+	Modify the miniz benchmark to use its own version of malloc, free
+	and realloc to reduce library and OS dependency.
+
+	* src/miniz/miniz.c: Define MINIZ_NO_MALLOC and MZ_MALLOC, MZ_FREE
+	and MZ_REALLOC invoking BEEBS variants.
+	(init_heap, malloc_beebs, realloc_beebs, free_beebs): Created.
+	* src/miniz/miniz_b.c (initialise_benchmark): Add call to init_heap.
+
+2019-04-18  Jeremy Bennett  <jeremy.bennett@embecosm.com>
+
 	Modify the huffbench benchmark to use its own version of malloc
 	and free to reduce library and OS dependency.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,18 @@
 2019-04-18  Jeremy Bennett  <jeremy.bennett@embecosm.com>
 
+	Modify both trio benchmarks to use there own version of malloc,
+	free and calloc to reduce library and OS dependency.
+
+	* src/trio/trio.c (init_heap, malloc_beebs, realloc_beebs)
+	(free_beebs): Created.
+	* src/trio/trio.h: Add declarations for init_heap, malloc_beebs,
+	realloc_beebs, and free_beebs.
+	* src/trio/trio_test.c (initialise_benchmark): add call to init_heap.
+	* src/trio/triop.h: Point macros to malloc_beebs, realloc_beebs,
+	and free_beebs.
+
+2019-04-18  Jeremy Bennett  <jeremy.bennett@embecosm.com>
+
 	Modify all the sglib benchmarks to use there own version of malloc
 	and free to reduce library and OS dependency.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,13 @@
 2019-04-18  Jeremy Bennett  <jeremy.bennett@embecosm.com>
 
+	Modify the fasta benchmark to use alloca rather than malloc to
+	reduce library and OS dependency.
+
+	* src/fasta/libfasta.c (repeat_fasta): Replace use of malloc by
+	alloca, and comment out associated call to free.
+
+2019-04-18  Jeremy Bennett  <jeremy.bennett@embecosm.com>
+
 	Modify the dtoa benchmark to use its own version of malloc and
 	free to reduce library and OS dependency.  For this benchmark,
 	hooks are provided to facilitate this.

--- a/src/dijkstra/dijkstra_small.c
+++ b/src/dijkstra/dijkstra_small.c
@@ -1,4 +1,3 @@
-
 /* This file is part of the Bristol/Embecosm Embedded Benchmark Suite.
 
    This program is free software: you can redistribute it and/or modify
@@ -71,9 +70,74 @@ int ch;
 int iPrev, iNode;
 int i, iCost, iDist;
 
+
+/* BEEBS heap is just an array */
+
+#include <stddef.h>
+
+#define QHEAP_SIZE (8192 / sizeof (QITEM))
+static QITEM qheap[QHEAP_SIZE];
+static QITEM *qfree_list;
+
+/* Initialize the BEEBS heap.
+
+   Because we know the size of objects is always the same, we have a
+   specially hacked version of malloc */
+
+static void
+qinit_heap (void)
+{
+  qfree_list = NULL;
+  int  i;
+
+  for (i = 0; i < QHEAP_SIZE; i++)
+    {
+      qheap[i].qNext = qfree_list;
+      qfree_list = &(qheap[i]);
+    }
+}
+
+/* BEEBS version of malloc.
+
+   This is primarily to reduce library and OS dependencies. This is unusual
+   for an embedded program in its dynamic use of malloc and free.  However we
+   know that malloc is always used with the same sized object, so we cheat. */
+
+static void *
+qmalloc_beebs (size_t size)
+{
+  if ((size != sizeof(QITEM)) || (0 == size))
+    return NULL;
+
+  QITEM *new_ptr = qfree_list;
+
+  if (new_ptr != NULL)
+    {
+      qfree_list = new_ptr->qNext;
+    }
+
+  return (void *) new_ptr;
+}
+
+/* BEEBS version of free.
+
+   Even our simplified version has to work correctly, or we'll run out of
+   memory. Assume we are given a valid pointer to a QITEM - there is no way
+   to check. */
+
+static void
+qfree_beebs (void *ptr)
+{
+  QITEM *qptr = (QITEM *) ptr;
+
+  qptr->qNext = qfree_list;
+  qfree_list = qptr;
+}
+
+
 void enqueue (int iNode, int iDist, int iPrev)
 {
-   QITEM *qNew = (QITEM *) malloc(sizeof(QITEM));
+   QITEM *qNew = (QITEM *) qmalloc_beebs(sizeof(QITEM));
    QITEM *qLast = qHead;
 
    qNew->iNode = iNode;
@@ -139,7 +203,7 @@ int dijkstra(int chStart, int chEnd)
       {
          QITEM *tmp = dequeue (&iNode, &iDist, &iPrev);
          if(tmp != 0)
-            free(tmp);
+            qfree_beebs(tmp);
          for (i = 0; i < NUM_NODES; i++)
          {
             iCost = AdjMatrix[iNode][i];
@@ -166,6 +230,7 @@ int output_count = 0;
 void
 initialise_benchmark (void)
 {
+  qinit_heap ();		/* Set up the BEEBS QITEM heap */
 }
 
 

--- a/src/dtoa/libdtoa.c
+++ b/src/dtoa/libdtoa.c
@@ -557,7 +557,7 @@ static void *heap_end;
 /* Initialize the BEEBS heap pointers */
 
 static void
-init_heap ()
+init_heap (void)
 {
     heap_ptr = (void *) heap;
     heap_end = heap_ptr + HEAP_SIZE;

--- a/src/dtoa/libdtoa.c
+++ b/src/dtoa/libdtoa.c
@@ -234,6 +234,11 @@ typedef unsigned Long ULong;
 #include "locale.h"
 #endif
 
+/* BEEBS uses its own malloc and free */
+
+#define MALLOC malloc_beebs
+#define FREE free_beebs
+
 #ifdef Honor_FLT_ROUNDS
 #ifndef Trust_FLT_ROUNDS
 #include <fenv.h>
@@ -543,6 +548,50 @@ extern "C" double strtod(const char *s00, char **se);
 extern "C" char *dtoa(double d, int mode, int ndigits,
 			int *decpt, int *sign, char **rve);
 #endif
+
+#define HEAP_SIZE 8192
+static char heap[HEAP_SIZE];
+static void *heap_ptr;
+static void *heap_end;
+
+/* Initialize the BEEBS heap pointers */
+
+static void
+init_heap ()
+{
+    heap_ptr = (void *) heap;
+    heap_end = heap_ptr + HEAP_SIZE;
+}
+
+/* BEEBS version of malloc.
+
+   This is primarily to reduce library and OS dependencies. Malloc is
+   generally not used in embedded code, or if it is, only in well defined
+   contexts to pre-allocate a fixed amount of memory. So this simplistic
+   implementation is just fine. */
+
+void *
+malloc_beebs (size_t size)
+{
+    void *new_ptr = heap_ptr;
+
+    if (((heap_ptr + size) > heap_end) || (0 == size))
+	return NULL;
+    else
+	{
+	    heap_ptr += size;
+	    return new_ptr;
+	}
+}
+
+/* BEEBS version of free.
+
+   For our simplified version of memory handling, free can just do nothing. */
+
+void
+free_beebs (void *ptr)
+{
+}
 
  struct
 Bigint {
@@ -4243,6 +4292,7 @@ char *nums[] = {"238434.3459823", "23955.0", "0.01000000023123", "1.0", "5555.55
 void
 initialise_benchmark (void)
 {
+  init_heap ();
 }
 
 

--- a/src/fasta/libfasta.c
+++ b/src/fasta/libfasta.c
@@ -1,5 +1,3 @@
-
-
 /* BEEBS fasta benchmark
 
    Copyright (C) 2014 Embecosm Limited and University of Bristol
@@ -108,7 +106,9 @@ static inline void accumulate_probabilities (aminoacid_t *genelist, size_t len) 
 static void repeat_fasta (char const *s, size_t count) {
     size_t pos = 0;
     size_t len = strlen (s);
-    char *s2 = malloc (len + WIDTH);
+    /* BEEBS uses alloca, to avoid library and OS dependencies
+       char *s2 = malloc (len + WIDTH); */
+    char *s2 = alloca (len + WIDTH);
     memcpy (s2, s, len);
     memcpy (s2 + len, s, WIDTH);
     do {
@@ -119,7 +119,8 @@ static void repeat_fasta (char const *s, size_t count) {
      	if (pos >= len) pos -= len;
      	count -= line;
     } while (count);
-    free (s2);
+    /* Since BEEBS uses alloca don't try to free!
+       free (s2);*/
 }
 
 /* This function takes a pointer to the first element of an array */

--- a/src/huffbench/libhuffbench.c
+++ b/src/huffbench/libhuffbench.c
@@ -73,7 +73,7 @@ static void *heap_end;
 /* Initialize the BEEBS heap pointers */
 
 static void
-init_heap ()
+init_heap (void)
 {
     heap_ptr = (void *) heap;
     heap_end = heap_ptr + HEAP_SIZE;

--- a/src/huffbench/libhuffbench.c
+++ b/src/huffbench/libhuffbench.c
@@ -1,5 +1,3 @@
-
-
 /* BEEBS cover benchmark
 
     huffbench
@@ -63,6 +61,54 @@
 #define SCALE_FACTOR    (REPEAT_FACTOR >> 0)
 
 
+/* BEEBS heap is just an array */
+
+#include <stddef.h>
+
+#define HEAP_SIZE 8192
+static char heap[HEAP_SIZE];
+static void *heap_ptr;
+static void *heap_end;
+
+/* Initialize the BEEBS heap pointers */
+
+static void
+init_heap ()
+{
+    heap_ptr = (void *) heap;
+    heap_end = heap_ptr + HEAP_SIZE;
+}
+
+/* BEEBS version of malloc.
+
+   This is primarily to reduce library and OS dependencies. Malloc is
+   generally not used in embedded code, or if it is, only in well defined
+   contexts to pre-allocate a fixed amount of memory. So this simplistic
+   implementation is just fine. */
+
+static void *
+malloc_beebs (size_t size)
+{
+    void *new_ptr = heap_ptr;
+
+    if (((heap_ptr + size) > heap_end) || (0 == size))
+	return NULL;
+    else
+	{
+	    heap_ptr += size;
+	    return new_ptr;
+	}
+}
+
+/* BEEBS version of free.
+
+   For our simplified version of memory handling, free can just do nothing. */
+
+static void
+free_beebs (void *ptr)
+{
+}
+
 // embedded random number generator; ala Park and Miller
 static       long seed = 1325;
 static const long IA   = 16807;
@@ -102,7 +148,7 @@ byte * generate_test_data(size_t n)
 {
     char * codes = "ABCDEFGHIJKLMNOPQRSTUVWXYZ012345";
 
-    byte * result = (byte *)malloc(n);
+    byte * result = (byte *)malloc_beebs(n);
     byte * ptr = result;
 
     int i;
@@ -159,7 +205,7 @@ void compdecomp(byte * data, size_t data_len)
     */
 
     // allocate data space
-    byte * comp = (byte *)malloc(data_len + 1);
+    byte * comp = (byte *)malloc_beebs(data_len + 1);
 
     size_t freq[512];   // allocate frequency table
     size_t heap[256];   // allocate heap
@@ -438,7 +484,7 @@ void compdecomp(byte * data, size_t data_len)
     }
 
     // remove work areas
-    free(comp);
+    free_beebs(comp);
 }
 
 
@@ -454,6 +500,7 @@ verify_benchmark (int res __attribute ((unused)) )
 void
 initialise_benchmark (void)
 {
+  init_heap ();
 }
 
 
@@ -467,9 +514,8 @@ int benchmark()
     compdecomp(test_data,TEST_SIZE);
 
     // release resources
-    free(test_data);
+    free_beebs(test_data);
 
     // done
     return 0;
 }
-

--- a/src/miniz/miniz_b.c
+++ b/src/miniz/miniz_b.c
@@ -49,9 +49,12 @@ verify_benchmark (int res __attribute ((unused)) )
 }
 
 
+extern void  init_heap (void);
+
 void
 initialise_benchmark (void)
 {
+  init_heap ();			/* Set up BEEBS heap */
 }
 
 

--- a/src/qrduino/qrtest.c
+++ b/src/qrduino/qrtest.c
@@ -47,10 +47,13 @@ benchmark (void)
   return 0;
 }
 
+extern void init_heap (void);
+
 void initialise_benchmark() {
   static const char *in_encode = "http://www.mageec.com";
   encode = in_encode;
   size = 22;
+  init_heap ();
 }
 
 int verify_benchmark(int unused) {

--- a/src/sglib-dllist/dllist.c
+++ b/src/sglib-dllist/dllist.c
@@ -51,6 +51,54 @@ int array[100] = {14, 66, 12, 41, 86, 69, 19, 77, 68, 38, 26, 42, 37, 23, 17, 29
   27, 47, 34, 35, 62, 97, 2, 79, 98, 25, 22, 65, 71, 0};
 
 
+/* BEEBS heap is just an array */
+
+#include <stddef.h>
+
+#define HEAP_SIZE 8192
+static char heap[HEAP_SIZE];
+static void *heap_ptr;
+static void *heap_end;
+
+/* Initialize the BEEBS heap pointers */
+
+static void
+init_heap (void)
+{
+    heap_ptr = (void *) heap;
+    heap_end = heap_ptr + HEAP_SIZE;
+}
+
+/* BEEBS version of malloc.
+
+   This is primarily to reduce library and OS dependencies. Malloc is
+   generally not used in embedded code, or if it is, only in well defined
+   contexts to pre-allocate a fixed amount of memory. So this simplistic
+   implementation is just fine. */
+
+static void *
+malloc_beebs (size_t size)
+{
+    void *new_ptr = heap_ptr;
+
+    if (((heap_ptr + size) > heap_end) || (0 == size))
+	return NULL;
+    else
+	{
+	    heap_ptr += size;
+	    return new_ptr;
+	}
+}
+
+/* BEEBS version of free.
+
+   For our simplified version of memory handling, free can just do nothing. */
+
+static void
+free_beebs (void *ptr)
+{
+}
+
 /* This benchmark does not support verification */
 
 int
@@ -63,6 +111,7 @@ verify_benchmark (int res __attribute ((unused)) )
 void
 initialise_benchmark (void)
 {
+  init_heap ();
 }
 
 
@@ -77,7 +126,7 @@ int benchmark()
   the_list = NULL;
   for(i = 0 ;i<100; ++i)
   {
-    l = malloc(sizeof(dllist));
+    l = malloc_beebs(sizeof(dllist));
     l->i = array[i];
     sglib_dllist_add(&the_list, l);
   }
@@ -100,7 +149,7 @@ int benchmark()
   for(l=sglib_dllist_it_init(&it,the_list); l!=NULL; l=sglib_dllist_it_next(&it))
   {
     cnt += l->i;
-    free(l);
+    free_beebs(l);
   }
 
   return cnt;

--- a/src/sglib-hashtable/hashtable.c
+++ b/src/sglib-hashtable/hashtable.c
@@ -1,5 +1,3 @@
-
-
 /* BEEBS hash benchmark
 
    Copyright (C) 2014 Embecosm Limited and University of Bristol
@@ -59,6 +57,54 @@ int array[100] = {14, 66, 12, 41, 86, 69, 19, 77, 68, 38, 26, 42, 37, 23, 17, 29
   27, 47, 34, 35, 62, 97, 2, 79, 98, 25, 22, 65, 71, 0};
 
 
+/* BEEBS heap is just an array */
+
+#include <stddef.h>
+
+#define HEAP_SIZE 8192
+static char heap[HEAP_SIZE];
+static void *heap_ptr;
+static void *heap_end;
+
+/* Initialize the BEEBS heap pointers */
+
+static void
+init_heap (void)
+{
+    heap_ptr = (void *) heap;
+    heap_end = heap_ptr + HEAP_SIZE;
+}
+
+/* BEEBS version of malloc.
+
+   This is primarily to reduce library and OS dependencies. Malloc is
+   generally not used in embedded code, or if it is, only in well defined
+   contexts to pre-allocate a fixed amount of memory. So this simplistic
+   implementation is just fine. */
+
+static void *
+malloc_beebs (size_t size)
+{
+    void *new_ptr = heap_ptr;
+
+    if (((heap_ptr + size) > heap_end) || (0 == size))
+	return NULL;
+    else
+	{
+	    heap_ptr += size;
+	    return new_ptr;
+	}
+}
+
+/* BEEBS version of free.
+
+   For our simplified version of memory handling, free can just do nothing. */
+
+static void
+free_beebs (void *ptr)
+{
+}
+
 /* This benchmark does not support verification */
 
 int
@@ -71,6 +117,7 @@ verify_benchmark (int res __attribute ((unused)) )
 void
 initialise_benchmark (void)
 {
+  init_heap ();
 }
 
 
@@ -87,7 +134,7 @@ int benchmark()
   for (i=0; i<100; i++) {
     ii.i = array[i];
     if (sglib_hashed_ilist_find_member(htab, &ii) == NULL) {
-      nn = malloc(sizeof(struct ilist));
+      nn = malloc_beebs(sizeof(struct ilist));
       nn->i = array[i];
       sglib_hashed_ilist_add(htab, nn);
     }
@@ -101,7 +148,7 @@ int benchmark()
 
   for(ll=sglib_hashed_ilist_it_init(&it,htab); ll!=NULL; ll=sglib_hashed_ilist_it_next(&it)) {
       cnt += ll->i;
-      free(ll);
+      free_beebs(ll);
   }
 
   return cnt;

--- a/src/sglib-listsort/listsort.c
+++ b/src/sglib-listsort/listsort.c
@@ -1,4 +1,3 @@
-
 /* BEEBS listsort benchmark
 
    Copyright (C) 2014 Embecosm Limited and University of Bristol
@@ -44,9 +43,58 @@ int array[100] = {14, 66, 12, 41, 86, 69, 19, 77, 68, 38, 26, 42, 37, 23, 17, 29
   64, 5, 30, 82, 72, 46, 59, 9, 7, 3, 39, 31, 4, 73, 70, 60, 58, 81, 56, 51, 45, 1, 6, 49,
   27, 47, 34, 35, 62, 97, 2, 79, 98, 25, 22, 65, 71, 0};
 
+/* BEEBS heap is just an array */
+
+#include <stddef.h>
+
+#define HEAP_SIZE 8192
+static char heap[HEAP_SIZE];
+static void *heap_ptr;
+static void *heap_end;
+
+/* Initialize the BEEBS heap pointers */
+
+static void
+init_heap (void)
+{
+    heap_ptr = (void *) heap;
+    heap_end = heap_ptr + HEAP_SIZE;
+}
+
+/* BEEBS version of malloc.
+
+   This is primarily to reduce library and OS dependencies. Malloc is
+   generally not used in embedded code, or if it is, only in well defined
+   contexts to pre-allocate a fixed amount of memory. So this simplistic
+   implementation is just fine. */
+
+static void *
+malloc_beebs (size_t size)
+{
+    void *new_ptr = heap_ptr;
+
+    if (((heap_ptr + size) > heap_end) || (0 == size))
+	return NULL;
+    else
+	{
+	    heap_ptr += size;
+	    return new_ptr;
+	}
+}
+
+/* BEEBS version of free.
+
+   For our simplified version of memory handling, free can just do nothing. */
+
+static void
+free_beebs (void *ptr)
+{
+}
+
 void
 initialise_benchmark (void)
 {
+  init_heap ();
 }
 
 
@@ -59,7 +107,7 @@ int benchmark()
 
   the_list = NULL;
   for (i=0; i<100; i++) {
-    l = malloc(sizeof(struct ilist));
+    l = malloc_beebs(sizeof(struct ilist));
     l->i = array[i];
     SGLIB_LIST_ADD(struct ilist, the_list, l, next_ptr);
   }
@@ -73,7 +121,7 @@ int benchmark()
   });
   // free all
   SGLIB_LIST_MAP_ON_ELEMENTS(struct ilist, the_list, ll, next_ptr, {
-    free(ll);
+    free_beebs(ll);
   });
   return cnt;
 }

--- a/src/sglib-rbtree/rbtree.c
+++ b/src/sglib-rbtree/rbtree.c
@@ -49,9 +49,58 @@ int array[100] = {14, 66, 12, 41, 86, 69, 19, 77, 68, 38, 26, 42, 37, 23, 17, 29
   64, 5, 30, 82, 72, 46, 59, 9, 7, 3, 39, 31, 4, 73, 70, 60, 58, 81, 56, 51, 45, 1, 6, 49,
   27, 47, 34, 35, 62, 97, 2, 79, 98, 25, 22, 65, 71, 0};
 
+/* BEEBS heap is just an array */
+
+#include <stddef.h>
+
+#define HEAP_SIZE 8192
+static char heap[HEAP_SIZE];
+static void *heap_ptr;
+static void *heap_end;
+
+/* Initialize the BEEBS heap pointers */
+
+static void
+init_heap (void)
+{
+    heap_ptr = (void *) heap;
+    heap_end = heap_ptr + HEAP_SIZE;
+}
+
+/* BEEBS version of malloc.
+
+   This is primarily to reduce library and OS dependencies. Malloc is
+   generally not used in embedded code, or if it is, only in well defined
+   contexts to pre-allocate a fixed amount of memory. So this simplistic
+   implementation is just fine. */
+
+static void *
+malloc_beebs (size_t size)
+{
+    void *new_ptr = heap_ptr;
+
+    if (((heap_ptr + size) > heap_end) || (0 == size))
+	return NULL;
+    else
+	{
+	    heap_ptr += size;
+	    return new_ptr;
+	}
+}
+
+/* BEEBS version of free.
+
+   For our simplified version of memory handling, free can just do nothing. */
+
+static void
+free_beebs (void *ptr)
+{
+}
+
 void
 initialise_benchmark (void)
 {
+  init_heap ();
 }
 
 
@@ -67,7 +116,7 @@ int benchmark()
   for (i=0; i<100; i++) {
     e.n = array[i];
     if (sglib_rbtree_find_member(the_tree, &e)==NULL) {
-      t = malloc(sizeof(struct rbtree));
+      t = malloc_beebs(sizeof(struct rbtree));
       t->n = array[i];
       sglib_rbtree_add(&the_tree, t);
     }
@@ -78,7 +127,7 @@ int benchmark()
   }
 
   for(te=sglib_rbtree_it_init(&it,the_tree); te!=NULL; te=sglib_rbtree_it_next(&it)) {
-    free(te);
+    free_beebs(te);
   }
 
   return cnt;

--- a/src/trio/trio.h
+++ b/src/trio/trio.h
@@ -251,4 +251,9 @@ void trio_locale_set_grouping TRIO_PROTO((char *grouping));
 
 #endif /* WITHOUT_TRIO */
 
+void init_heap (void);
+void *malloc_beebs (size_t size);
+void *realloc_beebs (void *ptr, size_t size);
+void free_beebs (void *ptr);
+
 #endif /* TRIO_TRIO_H */

--- a/src/trio/trio_test.c
+++ b/src/trio/trio_test.c
@@ -41,6 +41,7 @@ verify_benchmark (int res __attribute ((unused)) )
 void
 initialise_benchmark (void)
 {
+  init_heap ();			/* BEEBS memory allocator */
 }
 
 

--- a/src/trio/triop.h
+++ b/src/trio/triop.h
@@ -403,13 +403,13 @@ extern "C" {
  * Memory handling
  */
 #ifndef TRIO_MALLOC
-# define TRIO_MALLOC(n) malloc(n)
+# define TRIO_MALLOC(n) malloc_beebs(n)
 #endif
 #ifndef TRIO_REALLOC
-# define TRIO_REALLOC(x,n) realloc((x),(n))
+# define TRIO_REALLOC(x,n) realloc_beebs((x),(n))
 #endif
 #ifndef TRIO_FREE
-# define TRIO_FREE(x) free(x)
+# define TRIO_FREE(x) free_beebs(x)
 #endif
 
 


### PR DESCRIPTION
This set of commits remove the reliance on a system `malloc` implementation. There is still some more work to be done, particularly on behavior when malloc etc fails. But with this patch all but fdct and nettle-md5 will execute to completion without a working system malloc.