### PR TITLE
Allow size program to be specified in an environment variable.

### DIFF
--- a/testsuite/ChangeLog
+++ b/testsuite/ChangeLog
@@ -1,3 +1,8 @@
+2019-04-24  Jeremy Bennett  <jeremy.bennett@embecosm.com>
+
+	* lib/beebs.exp (beebs_size_all_benchmarks): Use the program in
+	the SIZE_PROG environment variable to measure size if specified.
+
 2019-04-10  Jeremy Bennett  <jeremy.bennett@embecosm.com>
 
 	This gives greater flexibility when testing with BEEBS.  The

--- a/testsuite/lib/beebs.exp
+++ b/testsuite/lib/beebs.exp
@@ -229,10 +229,20 @@ proc beebs_size_all_benchmarks { board objdir } {
     # and beebs could get different results if they have a different
     # version of size installed.  That's a risk, but for now, allowing
     # accurate results seems worth it.
+
+    global env
+    if { [llength [array names env SIZE_PROG]] > 0 } {
+	set size_prog $env(SIZE_PROG)
+    } else {
+	set size_prog "size"
+    }
+
+    verbose -log "size_prog set to $size_prog"
+
     set use_size_gnu_format 0
     set size_args ""
     verbose -log "Check if 'size --format=GNU' is supported"
-    spawn size --format=GNU
+    spawn ${size_prog} --format=GNU
     expect {
         -re {: invalid argument to --format:} {
             verbose -log "GNU format not supported"
@@ -257,7 +267,7 @@ proc beebs_size_all_benchmarks { board objdir } {
         if { [file isfile ${benchmark_file}] &&
 	     [file executable ${benchmark_file}]} {
 	    set timeout 1
-	    spawn size ${size_args} ${benchmark_file}
+	    spawn ${size_prog} ${size_args} ${benchmark_file}
 
 	    expect {
 		-re {\s*(\d+)\s+(\d+)\s+(\d+)\s+(\d+\s+[[:xdigit:]]+\s+)?[[:alnum:]_/.-]+} {


### PR DESCRIPTION
testsuite/ChangeLog:

	* lib/beebs.exp (beebs_size_all_benchmarks): Use the program in
	the SIZE_PROG environment variable to measure size if specified.