### PR TITLE
Changes to crc32 and st verify_benchmark routines

### DIFF
--- a/src/crc32/crc_32.c
+++ b/src/crc32/crc_32.c
@@ -200,7 +200,7 @@ int benchmark()
 
 int verify_benchmark(int r)
 {
-  int expected = 1207487004;
+  int expected = 171698305;
 
   if (r != expected)
     return 0;

--- a/src/st/libst.c
+++ b/src/st/libst.c
@@ -195,18 +195,20 @@ int RandomInteger()
 }
 
 int verify_benchmark(int unused) {
+  double epsilon = 0.00000000001;
   double expSumA = 4999.002470660901963128708302974700927734375;
   double expSumB = 4996.843113032735345768742263317108154296875;
   double expCoef = 0.99990005485361932446863875156850554049015045166016;
-  if (expSumA != SumA) {
+
+  if (fabs(expSumA-SumA) > epsilon) {
     //printf("%.50f\n, %.50f\n\n", SumA, expSumA);
     return 0;
   }
-  if(expSumB != SumB) {
+  if(fabs(expSumB-SumB) > epsilon) {
     //printf("%.50f\n, %.50f\n\n", SumB, expSumB);
     return 0;
   }
-  if(expCoef != Coef) {
+  if(fabs(expCoef-Coef) > epsilon) {
     //printf("%.50f\n, %.50f\n\n", Coef, expCoef);
     return 0;
   }


### PR DESCRIPTION
- The crc32 result verified against ([here](https://github.com/mageec/beebs/blob/c3ba9ad7aa30171dc8fc70e1059d602f05b022cf/src/crc32/crc_32.c#L203)) seems to be wrong. An x86 machine and a RISC-V machine appear to converge on `171698305`.
- If compiler optimization optimized this [line](https://github.com/mageec/beebs/blob/049ded9f3aeb5591f553879d3a0376b8614e9422/src/st/libst.c#L171), `Coef = numerator / (sqrt(Aterm) * sqrt(Bterm));`, 
into `Coef = numerator / (sqrt(Aterm*Bterm));`, the double FP result would be slightly different. To avoid failures due to these logically equivalent transformations, I added an epsilon check.