### PR TITLE
Fix bugs and improve verification in several benchmarks

### DIFF
--- a/src/bs/libbs.c
+++ b/src/bs/libbs.c
@@ -114,9 +114,9 @@ binary_search(int x)
 /* This benchmark does not support verification */
 
 int
-verify_benchmark (int res __attribute ((unused)) )
+verify_benchmark (int res)
 {
-  return -1;
+  return res == 900 ? 1 : 0;
 }
 
 
@@ -129,7 +129,6 @@ initialise_benchmark (void)
 
 int benchmark()
 {
-  binary_search(8);
-  return 0;
+  return binary_search(8);
 }
 

--- a/src/ctl/ctl.c
+++ b/src/ctl/ctl.c
@@ -35,7 +35,7 @@ typedef struct {
 #include <stddef.h>
 
 #define HEAP_SIZE 8192
-static char heap[HEAP_SIZE];
+static char heap[HEAP_SIZE] __attribute__((aligned(8)));
 static void *heap_ptr;
 static void *heap_end;
 

--- a/src/ns/libns.c
+++ b/src/ns/libns.c
@@ -1075,9 +1075,13 @@ int foo(int x)
 /* This benchmark does not support verification */
 
 int
-verify_benchmark (int res __attribute ((unused)) )
+verify_benchmark (int res)
 {
-  return -1;
+#ifdef FIND_TARGET
+  return res == 400 + 1111 ? 1 : 0;
+#else
+  return res == -1 ? 1 : 0;
+#endif
 }
 
 
@@ -1090,18 +1094,15 @@ initialise_benchmark (void)
 int
 benchmark(void)
 {
+  int result = foo(400);
 
 #ifdef TEST
 
-  printf("result=%d\n",foo(400));
-
-#else
-
-  foo(400);
+  printf("result=%d\n", result);
 
 #endif
 
-  return 0;
+  return result;
 }
 
 

--- a/src/trio/trio_test.c
+++ b/src/trio/trio_test.c
@@ -58,7 +58,7 @@ benchmark (void)
 
   return 0;
 }
-#elif TRIO_SSCANF
+#elif defined(TRIO_SSCANF)
 
 /* Global variables, so calls in BENCHMARK are not optimised away.  */
 volatile int int_dest;


### PR DESCRIPTION
Add `verify_benchmark()` for `bs` and `ns`, and fix bugs in `trio-sscanf` and `ctl-*`.