### PR TITLE
fix global buffer overflow

### DIFF
--- a/src/qsort/libqsort.c
+++ b/src/qsort/libqsort.c
@@ -84,7 +84,7 @@ int istack[100];
 
 void sort(unsigned long n)
 {
-	unsigned long i,ir=n,j,k,l=1;
+	unsigned long i,ir=n-1,j,k,l=0;
 	int jstack=0;
 	float a,temp;
 

--- a/src/select/libselect.c
+++ b/src/select/libselect.c
@@ -47,8 +47,8 @@ float select(unsigned long k, unsigned long n)
 	float a,temp;
 	int flag, flag2;
 
-	l=1;
-	ir=n;
+	l=0;
+	ir=n-1;
 	flag = flag2 = 0;
 	while (!flag) {
 		if (ir <= l+1) {


### PR DESCRIPTION
As mentioned in #78, global buffer overflow is found in `libqsort` and `libselect`.  I patched the code to fix such bug in this pull request.